### PR TITLE
Enable app layer to set status details

### DIFF
--- a/lib/grpcxx/conn.cpp
+++ b/lib/grpcxx/conn.cpp
@@ -133,10 +133,12 @@ void conn::write(response resp) noexcept {
 	_session.data(resp.id(), resp.bytes());
 	write();
 
+	const auto &status = resp.status();
 	_session.trailers(
 		resp.id(),
 		{
-			{"grpc-status", resp.status()},
+			{"grpc-status", status},
+			{"grpc-status-details-bin", status.details()},
 		});
 
 	write();

--- a/lib/grpcxx/h2/session.cpp
+++ b/lib/grpcxx/h2/session.cpp
@@ -102,6 +102,10 @@ void session::headers(int32_t stream_id, h2::headers hdrs) const {
 	nv.reserve(hdrs.size());
 
 	for (const auto &h : hdrs) {
+		if (h.value.empty()) {
+			continue;
+		}
+
 		nv.push_back({
 			const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(h.name.data())),
 			const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(h.value.data())),
@@ -175,6 +179,10 @@ void session::trailers(int32_t stream_id, h2::headers hdrs) const {
 	nv.reserve(hdrs.size());
 
 	for (const auto &h : hdrs) {
+		if (h.value.empty()) {
+			continue;
+		}
+
 		nv.push_back({
 			const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(h.name.data())),
 			const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(h.value.data())),

--- a/lib/grpcxx/response.h
+++ b/lib/grpcxx/response.h
@@ -13,8 +13,8 @@ public:
 
 	int32_t id() const noexcept { return _id; }
 
-	std::string      bytes() const noexcept { return _msg.bytes(); }
-	std::string_view status() noexcept { return _status; }
+	std::string bytes() const noexcept { return _msg.bytes(); }
+	const auto &status() noexcept { return _status; }
 
 	void data(std::string &&d) noexcept { _msg = std::move(d); }
 	void status(class status &&s) noexcept { _status = std::move(s); }

--- a/lib/grpcxx/status.h
+++ b/lib/grpcxx/status.h
@@ -26,8 +26,16 @@ public:
 	};
 
 	status(code_t code = code_t::ok) : _code(code), _str() {}
+	status(code_t code, std::string &&details) :
+		_code(code), _details(std::move(details)), _str() {}
 
-	operator std::string_view() {
+	operator std::string_view() const { return str(); }
+
+	code_t code() const noexcept { return _code; }
+
+	const std::string &details() const noexcept { return _details; }
+
+	std::string_view str() const {
 		if (_str.empty()) {
 			_str = std::to_string(static_cast<int8_t>(_code));
 		}
@@ -35,10 +43,10 @@ public:
 		return _str;
 	}
 
-	code_t code() const noexcept { return _code; }
-
 private:
 	code_t      _code;
-	std::string _str;
+	std::string _details;
+
+	mutable std::string _str;
 };
 } // namespace grpcxx


### PR DESCRIPTION
Close #11

⚠️ It's expected the app layer to set the correct base64 encoded status details.