### PR TITLE
Detailed error response example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,8 @@
+add_subdirectory(errors)
 add_subdirectory(helloworld)
 
 add_custom_target(examples)
 add_dependencies(examples
+	${PROJECT_NAME}-examples_errors
 	${PROJECT_NAME}-examples_helloworld
 )

--- a/examples/errors/CMakeLists.txt
+++ b/examples/errors/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_subdirectory(proto)
+
+add_executable(${PROJECT_NAME}-examples_errors
+	main.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}-examples_errors
+	PRIVATE
+		errors-proto
+		libgrpcxx::grpcxx
+)

--- a/examples/errors/README.md
+++ b/examples/errors/README.md
@@ -1,0 +1,29 @@
+# Errors
+
+This example demonstrates how to use [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/75c44112205d44183c3419d2c9cf4224e3c81d90/google/rpc/status.proto)
+messages to send back detailed gRPC error responses. Refer to https://github.com/uatuko/grpcxx/issues/11 for additional
+information on how this works.
+
+> 💡 The protobuf files in `proto/google/**` are copied from [googleapis](https://github.com/googleapis/googleapis/tree/master/google).
+
+e.g.
+```
+❯ grpcurl -vv -proto examples/errors/proto/examples/v1/errors.proto -plaintext localhost:7000 examples.v1.Errors/Test
+
+Resolved method descriptor:
+rpc Test ( .google.protobuf.Empty ) returns ( .google.protobuf.Empty );
+
+Request metadata to send:
+(empty)
+
+Response headers received:
+content-type: application/grpc
+
+Response trailers received:
+(empty)
+Sent 0 requests and received 0 responses
+ERROR:
+  Code: InvalidArgument
+  Message: Sample error message
+
+```

--- a/examples/errors/main.cpp
+++ b/examples/errors/main.cpp
@@ -1,0 +1,72 @@
+#include <cstdio>
+
+#include <google/rpc/code.pb.h>
+#include <google/rpc/status.pb.h>
+#include <grpcxx/server.h>
+
+#include "examples/v1/errors.grpcxx.pb.h"
+
+namespace b64 {
+static constexpr char alphabet[] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string encode(std::string_view in) {
+	std::string out;
+	out.reserve(4 * ((in.size() + 2) / 3)); // Encoding 3 bytes will result in 4 bytes
+
+	int i = 0, j = -6;
+	for (char c : in) {
+		i  = (i << 8) + c;
+		j += 8;
+
+		while (j >= 0) {
+			out.push_back(alphabet[(i >> j) & 0x3f]);
+			j -= 6;
+		}
+	}
+
+	if (j > -6) {
+		out.push_back(alphabet[((i << 8) >> (j + 8)) & 0x3f]);
+	}
+
+	while (out.size() % 4) {
+		out.push_back('=');
+	}
+
+	return out;
+}
+} // namespace b64
+
+using namespace examples::v1::Errors;
+template <>
+rpcTest::result_type ServiceImpl::call<rpcTest>(
+	grpcxx::context &ctx, const rpcTest::request_type &req) {
+	// Use google.rpc.Status to set detailed error response
+	google::rpc::Status status;
+	status.set_code(google::rpc::INVALID_ARGUMENT);
+	status.set_message("Sample error message");
+
+	// Serialise google.rpc.Status
+	auto data = status.SerializeAsString();
+
+	// base64 encode the serialised binary data
+	auto encoded = b64::encode(data);
+
+	// Construct a grpcxx::status with a status code and the b64 encoded error details
+	grpcxx::status s(static_cast<grpcxx::status::code_t>(status.code()), std::move(encoded));
+
+	return {s, std::nullopt};
+}
+
+int main() {
+	ServiceImpl impl;
+	Service     service(impl);
+
+	grpcxx::server server;
+	server.add(service);
+
+	std::printf("Listening on [127.0.0.1:7000] ...\n");
+	server.run("127.0.0.1", 7000);
+
+	return 0;
+}

--- a/examples/errors/proto/CMakeLists.txt
+++ b/examples/errors/proto/CMakeLists.txt
@@ -1,0 +1,23 @@
+# errors-proto
+add_library(errors-proto)
+target_sources(errors-proto
+	PRIVATE
+		examples/v1/errors.proto
+		google/rpc/code.proto
+		google/rpc/status.proto
+)
+
+target_include_directories(errors-proto
+	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+
+target_link_libraries(errors-proto
+	protobuf::libprotobuf
+)
+
+protobuf_generate(TARGET errors-proto)
+protobuf_generate(TARGET errors-proto
+	LANGUAGE grpcxx
+	GENERATE_EXTENSIONS .grpcxx.pb.h
+	PLUGIN "protoc-gen-grpcxx=\$<TARGET_FILE:libgrpcxx::protoc-gen>"
+)

--- a/examples/errors/proto/examples/v1/errors.proto
+++ b/examples/errors/proto/examples/v1/errors.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package examples.v1;
+
+import "google/protobuf/empty.proto";
+
+service Errors {
+	rpc Test(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}

--- a/examples/errors/proto/google/.clang-format
+++ b/examples/errors/proto/google/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/examples/errors/proto/google/rpc/code.proto
+++ b/examples/errors/proto/google/rpc/code.proto
@@ -1,0 +1,186 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/code;code";
+option java_multiple_files = true;
+option java_outer_classname = "CodeProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The canonical error codes for gRPC APIs.
+//
+//
+// Sometimes multiple error codes may apply.  Services should return
+// the most specific error code that applies.  For example, prefer
+// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
+// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
+enum Code {
+  // Not an error; returned on success.
+  //
+  // HTTP Mapping: 200 OK
+  OK = 0;
+
+  // The operation was cancelled, typically by the caller.
+  //
+  // HTTP Mapping: 499 Client Closed Request
+  CANCELLED = 1;
+
+  // Unknown error.  For example, this error may be returned when
+  // a `Status` value received from another address space belongs to
+  // an error space that is not known in this address space.  Also
+  // errors raised by APIs that do not return enough error information
+  // may be converted to this error.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  UNKNOWN = 2;
+
+  // The client specified an invalid argument.  Note that this differs
+  // from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
+  // that are problematic regardless of the state of the system
+  // (e.g., a malformed file name).
+  //
+  // HTTP Mapping: 400 Bad Request
+  INVALID_ARGUMENT = 3;
+
+  // The deadline expired before the operation could complete. For operations
+  // that change the state of the system, this error may be returned
+  // even if the operation has completed successfully.  For example, a
+  // successful response from a server could have been delayed long
+  // enough for the deadline to expire.
+  //
+  // HTTP Mapping: 504 Gateway Timeout
+  DEADLINE_EXCEEDED = 4;
+
+  // Some requested entity (e.g., file or directory) was not found.
+  //
+  // Note to server developers: if a request is denied for an entire class
+  // of users, such as gradual feature rollout or undocumented allowlist,
+  // `NOT_FOUND` may be used. If a request is denied for some users within
+  // a class of users, such as user-based access control, `PERMISSION_DENIED`
+  // must be used.
+  //
+  // HTTP Mapping: 404 Not Found
+  NOT_FOUND = 5;
+
+  // The entity that a client attempted to create (e.g., file or directory)
+  // already exists.
+  //
+  // HTTP Mapping: 409 Conflict
+  ALREADY_EXISTS = 6;
+
+  // The caller does not have permission to execute the specified
+  // operation. `PERMISSION_DENIED` must not be used for rejections
+  // caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
+  // instead for those errors). `PERMISSION_DENIED` must not be
+  // used if the caller can not be identified (use `UNAUTHENTICATED`
+  // instead for those errors). This error code does not imply the
+  // request is valid or the requested entity exists or satisfies
+  // other pre-conditions.
+  //
+  // HTTP Mapping: 403 Forbidden
+  PERMISSION_DENIED = 7;
+
+  // The request does not have valid authentication credentials for the
+  // operation.
+  //
+  // HTTP Mapping: 401 Unauthorized
+  UNAUTHENTICATED = 16;
+
+  // Some resource has been exhausted, perhaps a per-user quota, or
+  // perhaps the entire file system is out of space.
+  //
+  // HTTP Mapping: 429 Too Many Requests
+  RESOURCE_EXHAUSTED = 8;
+
+  // The operation was rejected because the system is not in a state
+  // required for the operation's execution.  For example, the directory
+  // to be deleted is non-empty, an rmdir operation is applied to
+  // a non-directory, etc.
+  //
+  // Service implementors can use the following guidelines to decide
+  // between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
+  //  (a) Use `UNAVAILABLE` if the client can retry just the failing call.
+  //  (b) Use `ABORTED` if the client should retry at a higher level. For
+  //      example, when a client-specified test-and-set fails, indicating the
+  //      client should restart a read-modify-write sequence.
+  //  (c) Use `FAILED_PRECONDITION` if the client should not retry until
+  //      the system state has been explicitly fixed. For example, if an "rmdir"
+  //      fails because the directory is non-empty, `FAILED_PRECONDITION`
+  //      should be returned since the client should not retry unless
+  //      the files are deleted from the directory.
+  //
+  // HTTP Mapping: 400 Bad Request
+  FAILED_PRECONDITION = 9;
+
+  // The operation was aborted, typically due to a concurrency issue such as
+  // a sequencer check failure or transaction abort.
+  //
+  // See the guidelines above for deciding between `FAILED_PRECONDITION`,
+  // `ABORTED`, and `UNAVAILABLE`.
+  //
+  // HTTP Mapping: 409 Conflict
+  ABORTED = 10;
+
+  // The operation was attempted past the valid range.  E.g., seeking or
+  // reading past end-of-file.
+  //
+  // Unlike `INVALID_ARGUMENT`, this error indicates a problem that may
+  // be fixed if the system state changes. For example, a 32-bit file
+  // system will generate `INVALID_ARGUMENT` if asked to read at an
+  // offset that is not in the range [0,2^32-1], but it will generate
+  // `OUT_OF_RANGE` if asked to read from an offset past the current
+  // file size.
+  //
+  // There is a fair bit of overlap between `FAILED_PRECONDITION` and
+  // `OUT_OF_RANGE`.  We recommend using `OUT_OF_RANGE` (the more specific
+  // error) when it applies so that callers who are iterating through
+  // a space can easily look for an `OUT_OF_RANGE` error to detect when
+  // they are done.
+  //
+  // HTTP Mapping: 400 Bad Request
+  OUT_OF_RANGE = 11;
+
+  // The operation is not implemented or is not supported/enabled in this
+  // service.
+  //
+  // HTTP Mapping: 501 Not Implemented
+  UNIMPLEMENTED = 12;
+
+  // Internal errors.  This means that some invariants expected by the
+  // underlying system have been broken.  This error code is reserved
+  // for serious errors.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  INTERNAL = 13;
+
+  // The service is currently unavailable.  This is most likely a
+  // transient condition, which can be corrected by retrying with
+  // a backoff. Note that it is not always safe to retry
+  // non-idempotent operations.
+  //
+  // See the guidelines above for deciding between `FAILED_PRECONDITION`,
+  // `ABORTED`, and `UNAVAILABLE`.
+  //
+  // HTTP Mapping: 503 Service Unavailable
+  UNAVAILABLE = 14;
+
+  // Unrecoverable data loss or corruption.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  DATA_LOSS = 15;
+}

--- a/examples/errors/proto/google/rpc/status.proto
+++ b/examples/errors/proto/google/rpc/status.proto
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The `Status` type defines a logical error model that is suitable for
+// different programming environments, including REST APIs and RPC APIs. It is
+// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+// three pieces of data: error code, error message, and error details.
+//
+// You can find out more about this error model and how to work with it in the
+// [API Design Guide](https://cloud.google.com/apis/design/errors).
+message Status {
+  // The status code, which should be an enum value of
+  // [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+  // by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There is a common set of
+  // message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}


### PR DESCRIPTION
Example demonstrating how to use `google.rpc.Status` to send back detailed error responses.

See #11 for more info.