### PR TITLE
(grpcxx) fix ordering of include files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,16 +28,18 @@ BreakInheritanceList: AfterColon
 ColumnLimit: 100
 IncludeBlocks: Regroup
 IncludeCategories:
-- Regex: <[[:alnum:]_]+>
+- Regex: ^"[[:alnum:].]+/
   Priority: 1
-- Regex: <[[:alnum:].]+>
+- Regex: ^"[[:alnum:]]*
   Priority: 2
-- Regex: ^<[[:alnum:]]+/
+- Regex: ^<[[:alnum:]_]+/
   Priority: 3
-- Regex: ^"[[:alnum:]]+/
+- Regex: ^<[[:alnum:]]+\.
   Priority: 4
-- Regex: .*
+- Regex: ^<[[:alnum:]_]+>
   Priority: 5
+- Regex: .*
+  Priority: 6
   SortPriority: 0
 InsertNewlineAtEOF: true
 PenaltyReturnTypeOnItsOwnLine: 200

--- a/.experiments/coroutines/conn.h
+++ b/.experiments/coroutines/conn.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <memory>
-#include <string>
+#include "reader.h"
+#include "writer.h"
 
 #include <uv.h>
 
-#include "reader.h"
-#include "writer.h"
+#include <memory>
+#include <string>
 
 class conn {
 public:

--- a/.experiments/coroutines/main.cpp
+++ b/.experiments/coroutines/main.cpp
@@ -1,6 +1,6 @@
-#include <cstdio>
-
 #include "server.h"
+
+#include <cstdio>
 
 int main() {
 	server s;

--- a/.experiments/coroutines/reader.h
+++ b/.experiments/coroutines/reader.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <coroutine>
-#include <memory>
+#include <cstddef>
 #include <string_view>
 
 class reader {

--- a/.experiments/coroutines/server.h
+++ b/.experiments/coroutines/server.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <cstdio>
-#include <future>
-#include <string>
+#include "conn.h"
+#include "task.h"
 
 #include <uv.h>
 
-#include "conn.h"
-#include "task.h"
+#include <cstdio>
+#include <future>
+#include <string>
 
 class server {
 public:

--- a/.experiments/coroutines/writer.h
+++ b/.experiments/coroutines/writer.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <coroutine>
-#include <memory>
-#include <string>
-
 #include <uv.h>
+
+#include <coroutine>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
 class writer {
 public:

--- a/.experiments/h2c/echo-server.h
+++ b/.experiments/h2c/echo-server.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <map>
-#include <string>
+#include <nghttp2/nghttp2.h>
 
 #include <uv.h>
 
-#include <nghttp2/nghttp2.h>
+#include <cstdint>
+#include <map>
+#include <string>
 
 struct h2_stream_t {
 	using headers_t = std::map<std::string, std::string>;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format.git
+  rev: v16.0.6
+  hooks:
+    - id: clang-format
+      name: Check C/C++ code formatting with clang-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.27)
 project(grpcxx VERSION 0.3.0 LANGUAGES CXX)
 
-cmake_policy(SET CMP0135 NEW)
-cmake_policy(SET CMP0144 NEW)
+cmake_policy(SET CMP0135 NEW) # CMake 3.24 
+cmake_policy(SET CMP0144 NEW) # CMake 3.27
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/bin/bench-results.js
+++ b/bin/bench-results.js
@@ -3,13 +3,13 @@
 const readline = require('readline');
 
 const reader = readline.createInterface({
-	input: process.stdin,
+	input : process.stdin,
 });
 
 async function main() {
-	const results = {};
-	let output = '';
-	let scenario = '';
+	const results  = {};
+	let   output   = '';
+	let   scenario = '';
 
 	for await (const line of reader) {
 		if (scenario === '' && !line.startsWith('[bench] :begin - ')) {
@@ -27,7 +27,7 @@ async function main() {
 				output,
 			};
 
-			output = '';
+			output   = '';
 			scenario = '';
 			continue;
 		}
@@ -35,34 +35,34 @@ async function main() {
 		output += `${line}\n`;
 
 		if (line.startsWith('finished in ')) {
-			const regex = /^.*, (.*) req\/s,.*$/;
+			const regex   = /^.*, (.*) req\/s,.*$/;
 			const matches = line.match(regex);
 
 			if (matches.length == 2) {
 				results[scenario] = {
 					...results[scenario],
-					result: Math.round(matches[1]),
+					result : Math.round(matches[1]),
 				};
 			};
 		}
 	}
 
 	let row = '| [TODO] |';
-	let md = '<details>\n' +
-		'<summary>[TODO]</summary>' +
-		'\n\n';
+	let md  = '<details>\n' +
+			 '<summary>[TODO]</summary>' +
+			 '\n\n';
 
 	for (const [scenario, result] of Object.entries(results)) {
 		md += `### ${scenario}\n` +
-			'```\n' +
-			`${result.output}` +
-			'```\n\n';
+			  '```\n' +
+			  `${result.output}` +
+			  '```\n\n';
 
 		row += ` ${Math.round(result.result / 1000)}k |`
 	}
 
 	md += '\n' +
-		'</details>\n';
+		  '</details>\n';
 
 	console.log(md);
 	console.log(row);

--- a/examples/errors/main.cpp
+++ b/examples/errors/main.cpp
@@ -1,10 +1,12 @@
-#include <cstdio>
+#include "examples/v1/errors.grpcxx.pb.h"
 
 #include <google/rpc/code.pb.h>
 #include <google/rpc/status.pb.h>
 #include <grpcxx/server.h>
 
-#include "examples/v1/errors.grpcxx.pb.h"
+#include <cstdio>
+#include <string>
+#include <string_view>
 
 namespace b64 {
 static constexpr char alphabet[] =

--- a/examples/helloworld/main.cpp
+++ b/examples/helloworld/main.cpp
@@ -1,8 +1,8 @@
-#include <cstdio>
+#include "helloworld/v1/greeter.grpcxx.pb.h"
 
 #include <grpcxx/server.h>
 
-#include "helloworld/v1/greeter.grpcxx.pb.h"
+#include <cstdio>
 
 using namespace helloworld::v1::Greeter;
 

--- a/lib/grpcxx/asio/conn.h
+++ b/lib/grpcxx/asio/conn.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <forward_list>
-#include <unordered_map>
+#include "../h2/session.h"
+#include "../request.h"
+#include "../response.h"
 
 #ifdef BOOST_ASIO_STANDALONE
 #include <boost/asio/awaitable.hpp>
@@ -11,9 +12,8 @@
 #include <asio/ip/tcp.hpp>
 #endif
 
-#include "../h2/session.h"
-#include "../request.h"
-#include "../response.h"
+#include <forward_list>
+#include <unordered_map>
 
 namespace grpcxx {
 namespace asio {

--- a/lib/grpcxx/asio/server.cpp
+++ b/lib/grpcxx/asio/server.cpp
@@ -1,5 +1,7 @@
 #include "server.h"
 
+#include "conn.h"
+
 #ifdef BOOST_ASIO_STANDALONE
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
@@ -13,8 +15,6 @@
 #include <asio/strand.hpp>
 #include <asio/write.hpp>
 #endif
-
-#include "conn.h"
 
 namespace grpcxx {
 namespace asio {

--- a/lib/grpcxx/asio/server.h
+++ b/lib/grpcxx/asio/server.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../server_base.h"
+
 #ifdef BOOST_ASIO_STANDALONE
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -8,7 +10,7 @@
 #include <asio/ip/tcp.hpp>
 #endif
 
-#include "../server_base.h"
+#include <string_view>
 
 namespace grpcxx {
 namespace asio {

--- a/lib/grpcxx/fixed_string.h
+++ b/lib/grpcxx/fixed_string.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <string_view>
 
 namespace grpcxx {

--- a/lib/grpcxx/h2/event.h
+++ b/lib/grpcxx/h2/event.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <map>
-#include <optional>
-#include <string>
-#include <string_view>
-
 #include "headers.h"
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
 
 namespace grpcxx {
 namespace h2 {

--- a/lib/grpcxx/h2/session.cpp
+++ b/lib/grpcxx/h2/session.cpp
@@ -1,6 +1,7 @@
 #include "session.h"
 
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <stdexcept>
 

--- a/lib/grpcxx/h2/session.h
+++ b/lib/grpcxx/h2/session.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include "event.h"
 
 #include <nghttp2/nghttp2.h>
 
-#include "event.h"
+#include <cstdint>
+#include <string>
+#include <vector>
 
 namespace grpcxx {
 namespace h2 {

--- a/lib/grpcxx/message.cpp
+++ b/lib/grpcxx/message.cpp
@@ -1,8 +1,9 @@
 #include "message.h"
 
 #include <array>
-#include <condition_variable>
+#include <cstdint>
 #include <stdexcept>
+#include <string>
 
 namespace grpcxx {
 namespace detail {

--- a/lib/grpcxx/request.h
+++ b/lib/grpcxx/request.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "message.h"
+
+#include <cstdint>
 #include <string>
 #include <unordered_map>
-
-#include "message.h"
 
 namespace grpcxx {
 namespace detail {

--- a/lib/grpcxx/response.h
+++ b/lib/grpcxx/response.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <string>
-
 #include "message.h"
 #include "status.h"
+
+#include <cstdint>
+#include <string>
 
 namespace grpcxx {
 namespace detail {

--- a/lib/grpcxx/rpc.h
+++ b/lib/grpcxx/rpc.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <functional>
-#include <optional>
-#include <string>
-
 #include "fixed_string.h"
 #include "status.h"
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
 namespace grpcxx {
 template <fixed_string M, typename T, typename U> struct rpc {

--- a/lib/grpcxx/server_base.h
+++ b/lib/grpcxx/server_base.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "context.h"
+#include "status.h"
+
 #include <functional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-
-#include "context.h"
-#include "status.h"
+#include <utility>
 
 namespace grpcxx {
 

--- a/lib/grpcxx/service.h
+++ b/lib/grpcxx/service.h
@@ -1,14 +1,15 @@
 #pragma once
 
+#include "context.h"
+#include "fixed_string.h"
+#include "status.h"
+
+#include <concepts>
 #include <functional>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <unordered_map>
-
-#include "context.h"
-#include "fixed_string.h"
-#include "status.h"
 
 namespace grpcxx {
 namespace concepts {

--- a/lib/grpcxx/status.h
+++ b/lib/grpcxx/status.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace grpcxx {
 class status {

--- a/lib/grpcxx/uv/conn.h
+++ b/lib/grpcxx/uv/conn.h
@@ -1,19 +1,21 @@
 #pragma once
 
+#include "../h2/session.h"
+#include "../request.h"
+#include "../response.h"
+
+#include "reader.h"
+#include "task.h"
+#include "writer.h"
+
+#include <uv.h>
+
+#include <cstdint>
 #include <forward_list>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-
-#include <uv.h>
-
-#include "../h2/session.h"
-#include "../request.h"
-#include "../response.h"
-#include "reader.h"
-#include "task.h"
-#include "writer.h"
 
 namespace grpcxx {
 namespace uv {

--- a/lib/grpcxx/uv/reader.h
+++ b/lib/grpcxx/uv/reader.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <uv.h>
+
 #include <coroutine>
+#include <cstdio>
 #include <memory>
 #include <string_view>
-
-#include <uv.h>
 
 namespace grpcxx {
 namespace uv {

--- a/lib/grpcxx/uv/scheduler.h
+++ b/lib/grpcxx/uv/scheduler.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "task.h"
+
+#include <uv.h>
+
 #include <condition_variable>
 #include <coroutine>
 #include <functional>
@@ -7,10 +11,6 @@
 #include <mutex>
 #include <queue>
 #include <thread>
-
-#include <uv.h>
-
-#include "task.h"
 
 namespace grpcxx {
 namespace uv {

--- a/lib/grpcxx/uv/server.cpp
+++ b/lib/grpcxx/uv/server.cpp
@@ -3,6 +3,9 @@
 #include "conn.h"
 #include "coroutine.h"
 
+#include <stdexcept>
+#include <string>
+
 namespace grpcxx {
 namespace uv {
 server::server(std::size_t n) noexcept : _scheduler(_loop, n) {

--- a/lib/grpcxx/uv/server.h
+++ b/lib/grpcxx/uv/server.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <string_view>
-#include <thread>
+#include "../server_base.h"
+
+#include "scheduler.h"
 
 #include <uv.h>
 
-#include "../server_base.h"
-#include "scheduler.h"
+#include <string_view>
+#include <thread>
 
 namespace grpcxx {
 namespace uv {

--- a/lib/grpcxx/uv/writer.cpp
+++ b/lib/grpcxx/uv/writer.cpp
@@ -1,5 +1,6 @@
 #include "writer.h"
 
+#include <stdexcept>
 #include <string>
 
 namespace grpcxx {

--- a/lib/grpcxx/uv/writer.h
+++ b/lib/grpcxx/uv/writer.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <uv.h>
+
 #include <coroutine>
+#include <exception>
 #include <memory>
 #include <string_view>
-
-#include <uv.h>
 
 namespace grpcxx {
 namespace uv {

--- a/src/protoc-gen-grpcxx/grpcxx.cpp
+++ b/src/protoc-gen-grpcxx/grpcxx.cpp
@@ -5,6 +5,9 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 
+#include <memory>
+#include <string>
+
 bool Grpcxx::Generate(
 	const google::protobuf::FileDescriptor *file, const std::string &parameter,
 	google::protobuf::compiler::GeneratorContext *context, std::string *error) const {

--- a/src/protoc-gen-grpcxx/grpcxx.h
+++ b/src/protoc-gen-grpcxx/grpcxx.h
@@ -2,6 +2,9 @@
 
 #include <google/protobuf/compiler/code_generator.h>
 
+#include <cstdint>
+#include <string>
+
 class Grpcxx : public google::protobuf::compiler::CodeGenerator {
 public:
 	Grpcxx() {}

--- a/src/protoc-gen-grpcxx/main.cpp
+++ b/src/protoc-gen-grpcxx/main.cpp
@@ -1,6 +1,6 @@
-#include <google/protobuf/compiler/plugin.h>
-
 #include "grpcxx.h"
+
+#include <google/protobuf/compiler/plugin.h>
 
 int main(int argc, char *argv[]) {
 	Grpcxx g;


### PR DESCRIPTION
While attempting to compile sources generated with grpcxx,
or the project itself when using GCC, I encountered some issues 
about missing standard include headers.

I added the missing includes, and I also inverted the include order 
so that local includes are always
present before system ones. This minimizes
the possibility that transitive dependencies
can silently satisfy an include requirement just
due to another local header carrying the dependency over.

Please test the Asio compilation before merging, as I am on Debian
12 and as such my version of boost is still 1.74.