### PR TITLE
chore(cmake): install and export artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
+option(GRPCXX_HERMETIC_BUILD "Fetch and build all dependencies instead of relying on system libraries" ON)
 option(GRPCXX_USE_ASIO "Use asio instead of libuv for I/O and event loop" OFF)
 
 include(CMakeDependentOption)
@@ -34,3 +35,27 @@ endif()
 
 add_subdirectory(lib)
 add_subdirectory(src)
+
+# Installation steps to make find_package(grpcxx) work
+# in other projects.
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+set(cmake_conf_dir ${CMAKE_INSTALL_LIBDIR}/cmake/grpcxx)
+configure_package_config_file(cmake/grpcxx-config.cmake.in cmake/grpcxx-config.cmake
+    INSTALL_DESTINATION ${cmake_conf_dir})
+write_basic_package_version_file(cmake/grpcxx-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMinorVersion)
+install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/cmake/grpcxx-version.cmake
+			${CMAKE_CURRENT_BINARY_DIR}/cmake/grpcxx-config.cmake
+        DESTINATION ${cmake_conf_dir}
+		COMPONENT Development)
+export(EXPORT grpcxx
+       FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/grpcxx-targets.cmake
+       NAMESPACE grpcxx::)
+install(EXPORT grpcxx
+        NAMESPACE grpcxx::
+        COMPONENT Development
+		FILE grpcxx-targets.cmake
+        DESTINATION ${cmake_conf_dir})

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,20 +1,39 @@
 include(FetchContent)
 
-if (NOT GRPCXX_USE_ASIO)
-	# libuv
-	FetchContent_Declare(libuv
-		URL      https://github.com/libuv/libuv/archive/refs/tags/v1.46.0.tar.gz
-		URL_HASH SHA256=7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
-	)
+set(LIBUV_MINVERSION 1.46.0)
+set(BOOST_MINVERSION 1.81)
+set(NGHTTP2_MINVERSION 1.55.1)
+set(PROTOBUF_MINVERSION 3.15.0)
+set(FMT_MINVERSION 10.1.1)
 
-	set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build libuv shared lib")
-	FetchContent_MakeAvailable(libuv)
-	add_library(libuv::uv ALIAS uv_a)
+if(NOT GRPCXX_USE_ASIO)
+	if(GRPCXX_HERMETIC_BUILD)
+		# libuv
+		FetchContent_Declare(libuv
+			URL      https://github.com/libuv/libuv/archive/refs/tags/v${LIBUV_MINVERSION}.tar.gz
+			URL_HASH SHA256=7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
+		)
+
+		set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build libuv shared lib")
+		FetchContent_MakeAvailable(libuv)
+		install(TARGETS uv_a EXPORT grpcxx COMPONENT Development)
+		add_library(libuv::uv ALIAS uv_a)
+	else()
+		# Unfortunately the libuv CMakeLists.txt does not export
+		# a version file. This is a bug in libuv.
+		# So we cannot use ${LIBUV_MINVERSION} in find_package().
+		# To work around it, we do a pkg_config call just to check
+		# the version.
+		find_package(PkgConfig REQUIRED)
+		pkg_check_modules(uv REQUIRED "libuv>=${LIBUV_MINVERSION}")
+		find_package(libuv REQUIRED)
+	endif()
 else()
 	# asio
 	add_library(asio INTERFACE)
+	install(TARGETS asio EXPORT grpcxx COMPONENT Development)
 
-	find_package(Boost 1.81)
+	find_package(Boost ${BOOST_MINVERSION})
 	if (Boost_FOUND)
 		message(STATUS "Found Boost ${Boost_VERSION} at ${Boost_INCLUDE_DIR}")
 
@@ -52,7 +71,7 @@ else()
 			endif()
 		endif()
 
-		if (NOT Asio_FOUND)
+		if (NOT Asio_FOUND AND GRPCXX_HERMETIC_BUILD)
 			FetchContent_Declare(asio
 				URL      https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-29-0.tar.gz
 				URL_HASH SHA256=44305859b4e6664dbbf853c1ef8ca0259d694f033753ae309fcb2534ca20f721
@@ -73,30 +92,41 @@ else()
 endif()
 
 # nghttp2
-FetchContent_Declare(nghttp2
-	URL      https://github.com/nghttp2/nghttp2/releases/download/v1.55.1/nghttp2-1.55.1.tar.xz
-	URL_HASH SHA256=19490b7c8c2ded1cf7c3e3a54ef4304e3a7876ae2d950d60a81d0dc6053be419
-)
+if(NOT GRPCXX_HERMETIC_BUILD)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(nghttp2 REQUIRED IMPORTED_TARGET "libnghttp2>=${NGHTTP2_MINVERSION}")
+	add_library(libnghttp2::nghttp2 ALIAS PkgConfig::nghttp2)
+else()
+	FetchContent_Declare(nghttp2
+		URL      https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2_MINVERSION}/nghttp2-${NGHTTP2_MINVERSION}.tar.xz
+		URL_HASH SHA256=19490b7c8c2ded1cf7c3e3a54ef4304e3a7876ae2d950d60a81d0dc6053be419
+	)
 
-set(ENABLE_LIB_ONLY   ON  CACHE BOOL "Build libnghttp2 only")
-set(ENABLE_STATIC_LIB ON  CACHE BOOL "Build libnghttp2 in static mode")
-set(ENABLE_SHARED_LIB OFF CACHE BOOL "Build libnghttp2 as a shared library")
-set(ENABLE_DOC        OFF CACHE BOOL "Build libnghttp2 documentation")
+	set(ENABLE_LIB_ONLY   ON  CACHE BOOL "Build libnghttp2 only")
+	set(ENABLE_STATIC_LIB ON  CACHE BOOL "Build libnghttp2 in static mode")
+	set(ENABLE_SHARED_LIB OFF CACHE BOOL "Build libnghttp2 as a shared library")
+	set(ENABLE_DOC        OFF CACHE BOOL "Build libnghttp2 documentation")
 
-FetchContent_MakeAvailable(nghttp2)
+	FetchContent_MakeAvailable(nghttp2)
+	target_include_directories(nghttp2_static
+		PUBLIC
+			$<BUILD_INTERFACE:${nghttp2_SOURCE_DIR}/lib/includes>
+	)
 
-target_include_directories(nghttp2_static
-	PUBLIC
-		$<BUILD_INTERFACE:${nghttp2_SOURCE_DIR}/lib/includes>
-)
-add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)
+	install(TARGETS nghttp2_static EXPORT grpcxx COMPONENT Development)
+	add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)
+endif()
 
 # protobuf
-find_package(Protobuf 3.15.0 REQUIRED)
+find_package(Protobuf ${PROTOBUF_MINVERSION} REQUIRED)
 
-# fmt
-FetchContent_Declare(fmt
-	URL      https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
-	URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
-)
-FetchContent_MakeAvailable(fmt)
+if(NOT GRPCXX_HERMETIC_BUILD)
+	find_package(fmt ${FMT_MINVERSION} REQUIRED)
+else()
+	# fmt
+	FetchContent_Declare(fmt
+		URL      https://github.com/fmtlib/fmt/archive/refs/tags/${FMT_MINVERSION}.tar.gz
+		URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
+	)
+	FetchContent_MakeAvailable(fmt)
+endif()

--- a/cmake/grpcxx-config.cmake.in
+++ b/cmake/grpcxx-config.cmake.in
@@ -1,0 +1,15 @@
+include(${CMAKE_CURRENT_LIST_DIR}/grpcxx-version.cmake)
+
+@PACKAGE_INIT@
+
+if(NOT grpcxx::grpcxx)
+    if(NOT @GRPCXX_HERMETIC_BUILD@)
+        if(NOT @GRPCXX_USE_ASIO@)
+            find_dependency(libuv REQUIRED)
+        endif()
+        find_dependency(Protobuf @PROTOBUF_MINVERSION@ REQUIRED)
+        find_dependency(fmt @FMT_MINVERSION@ REQUIRED)
+    endif()
+    
+    include(${CMAKE_CURRENT_LIST_DIR}/grpcxx-targets.cmake)
+endif()

--- a/lib/grpcxx/CMakeLists.txt
+++ b/lib/grpcxx/CMakeLists.txt
@@ -1,3 +1,9 @@
+# NOTE: if you wonder why we use header file set BASE_DIRS
+# of .., it is because other projects want to #include <grpcxx/something.h>.
+# Normally the CMakeLists.txt file for building a library would be
+# one level above, or the public headers into their own
+# subfolder, but this works too.
+
 add_library(grpcxx)
 target_sources(grpcxx
 	PRIVATE
@@ -7,6 +13,7 @@ target_sources(grpcxx
 		server_base.cpp
 	PUBLIC
 		FILE_SET headers TYPE HEADERS
+		BASE_DIRS ..
 		FILES
 			context.h
 			fixed_string.h
@@ -33,6 +40,7 @@ if (NOT GRPCXX_USE_ASIO)
 			uv/writer.cpp
 		PUBLIC
 			FILE_SET headers TYPE HEADERS
+			BASE_DIRS ..
 			FILES
 				uv/server.h
 				uv/scheduler.h
@@ -52,6 +60,7 @@ else()
 			asio/server.cpp
 		PUBLIC
 			FILE_SET headers TYPE HEADERS
+			BASE_DIRS ..
 			FILES
 				asio/server.h
 		PRIVATE
@@ -94,3 +103,9 @@ else()
 			GRPCXX_USE_ASIO
 	)
 endif()
+
+include(GNUInstallDirs)
+install(TARGETS grpcxx EXPORT grpcxx
+		LIBRARY COMPONENT Runtime
+        FILE_SET headers
+			COMPONENT Development)

--- a/src/protoc-gen-grpcxx/CMakeLists.txt
+++ b/src/protoc-gen-grpcxx/CMakeLists.txt
@@ -21,3 +21,7 @@ target_compile_definitions(protoc-gen-grpcxx
 		PLUGIN_NAME="$<TARGET_NAME:protoc-gen-grpcxx>"
 		PLUGIN_VERSION="${PROJECT_VERSION}"
 )
+
+install(TARGETS protoc-gen-grpcxx
+        EXPORT grpcxx
+		COMPONENT Development)


### PR DESCRIPTION
This adds the ability to install independently
the runtime components (the built library)
and the development component (the headers,
the protoc compiler plugin) and reuse them
in external CMake projects.

With this change I was able to build the
library in buildroot.