### PR TITLE
Handle UV server shutdown and allow socket activation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             ${{ matrix.dependencies }} \
-            cmake ninja-build \
+            cmake ninja-build git ca-certificates \
             libprotobuf-dev libprotoc-dev protobuf-compiler
 
       - uses: actions/checkout@v4
@@ -53,21 +53,30 @@ jobs:
           cmake -B .build -G Ninja \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON \
             ${{ matrix.cmake_args }}
       - name: Build
         run: |
           cmake --build .build --config Release
-
+      
+      - name: Test Project
+        uses: threeal/ctest-action@v1.1.0
+        with:
+          test-dir: .build
 
   macos:
-    runs-on: macos-13 # [Nov. 2023] `macos-latest` is pointing to `macos-12` which doesn't support coroutines.
+    runs-on: macos-15
     concurrency:
       group: ${{ github.workflow_ref }}-${{ github.job }}_${{ matrix.compiler }}-${{ matrix.variant }}
     strategy:
       fail-fast: false
       matrix:
         compiler:
-          - g++
+          # Right now, there is a bug in either libprotoc or GCC, which results in trying
+          # to link with undefined symbols. Unfortunately I don't have an ARM Mac to try.
+          # Compiling with clang (the default Mac OS X C++ compiler) should still prove
+          # a good degree of testing.
+          # - g++-14
           - clang++
         variant:
           - libuv
@@ -83,6 +92,7 @@ jobs:
           brew install \
             protobuf@3 \
             ninja \
+            git \
             ${{ matrix.dependencies }}
           brew link protobuf@3
 
@@ -94,10 +104,20 @@ jobs:
 
       - name: Configure CMake
         run: |
+          if [ ${{ matrix.compiler }} == "clang" ]; then
+            export PATH="$(brew --prefix llvm@18)/bin:${PATH}"; \
+          fi
+
           cmake -B .build -G Ninja \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON \
             ${{ matrix.cmake_args }}
       - name: Build
         run: |
           cmake --build .build --config Release
+      
+      - name: Test
+        uses: threeal/ctest-action@v1.1.0
+        with:
+          test-dir: .build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ endif()
 add_subdirectory(lib)
 add_subdirectory(src)
 
+if(BUILD_TESTING)
+    include(CTest)
+    enable_testing()
+    add_subdirectory(test)
+endif()
+
 # Installation steps to make find_package(grpcxx) work
 # in other projects.
 include(CMakePackageConfigHelpers)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,126 +7,145 @@ set(PROTOBUF_MINVERSION 3.15.0)
 set(FMT_MINVERSION 10.1.1)
 
 if(NOT GRPCXX_USE_ASIO)
-	if(GRPCXX_HERMETIC_BUILD)
-		# libuv
-		FetchContent_Declare(libuv
-			URL      https://github.com/libuv/libuv/archive/refs/tags/v${LIBUV_MINVERSION}.tar.gz
-			URL_HASH SHA256=7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
-		)
+    if(GRPCXX_HERMETIC_BUILD)
+        # libuv
+        FetchContent_Declare(libuv
+            URL      https://github.com/libuv/libuv/archive/refs/tags/v${LIBUV_MINVERSION}.tar.gz
+            URL_HASH SHA256=7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
+        )
 
-		set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build libuv shared lib")
-		FetchContent_MakeAvailable(libuv)
-		install(TARGETS uv_a EXPORT grpcxx COMPONENT Development)
-		add_library(libuv::uv ALIAS uv_a)
-	else()
-		# Unfortunately the libuv CMakeLists.txt does not export
-		# a version file. This is a bug in libuv.
-		# So we cannot use ${LIBUV_MINVERSION} in find_package().
-		# To work around it, we do a pkg_config call just to check
-		# the version.
-		find_package(PkgConfig REQUIRED)
-		pkg_check_modules(uv REQUIRED "libuv>=${LIBUV_MINVERSION}")
-		find_package(libuv REQUIRED)
-	endif()
+        set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build libuv shared lib")
+        FetchContent_MakeAvailable(libuv)
+        install(TARGETS uv_a EXPORT grpcxx COMPONENT Development)
+        add_library(libuv::uv ALIAS uv_a)
+    else()
+        # Unfortunately the libuv CMakeLists.txt does not export
+        # a version file. This is a bug in libuv.
+        # So we cannot use ${LIBUV_MINVERSION} in find_package().
+        # To work around it, we do a pkg_config call just to check
+        # the version.
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(uv REQUIRED "libuv>=${LIBUV_MINVERSION}")
+        find_package(libuv REQUIRED)
+    endif()
 else()
-	# asio
-	add_library(asio INTERFACE)
-	install(TARGETS asio EXPORT grpcxx COMPONENT Development)
+    # asio
+    add_library(asio INTERFACE)
+    install(TARGETS asio EXPORT grpcxx COMPONENT Development)
 
-	find_package(Boost ${BOOST_MINVERSION})
-	if (Boost_FOUND)
-		message(STATUS "Found Boost ${Boost_VERSION} at ${Boost_INCLUDE_DIR}")
+    find_package(Boost ${BOOST_MINVERSION})
+    if (Boost_FOUND)
+        message(STATUS "Found Boost ${Boost_VERSION} at ${Boost_INCLUDE_DIR}")
 
-		target_include_directories(asio INTERFACE ${Boost_INCLUDE_DIR})
-		target_compile_definitions(asio
-			INTERFACE
-				ASIO_NS=::boost::asio
-				BOOST_ASIO_STANDALONE
-				BOOST_ASIO_NO_DEPRECATED
-		)
-	else()
-		find_path(Asio_INCLUDE_DIR NAMES asio.hpp)
-		if (Asio_INCLUDE_DIR)
-			file(READ "${Asio_INCLUDE_DIR}/asio/version.hpp" tmp_version)
-			string(REGEX MATCH "#define ASIO_VERSION ([0-9]+)" REGEX_VERSION ${tmp_version})
+        target_include_directories(asio INTERFACE ${Boost_INCLUDE_DIR})
+        target_compile_definitions(asio
+            INTERFACE
+                ASIO_NS=::boost::asio
+                BOOST_ASIO_STANDALONE
+                BOOST_ASIO_NO_DEPRECATED
+        )
+    else()
+        find_path(Asio_INCLUDE_DIR NAMES asio.hpp)
+        if (Asio_INCLUDE_DIR)
+            file(READ "${Asio_INCLUDE_DIR}/asio/version.hpp" tmp_version)
+            string(REGEX MATCH "#define ASIO_VERSION ([0-9]+)" REGEX_VERSION ${tmp_version})
 
-			set(tmp_asio_version ${CMAKE_MATCH_1})
-			math(EXPR Asio_VERSION_MAJOR "${tmp_asio_version} / 100000")
-			math(EXPR Asio_VERSION_MINOR "${tmp_asio_version} / 100 % 1000")
-			math(EXPR Asio_VERSION_PATCH "${tmp_asio_version} % 100")
-			set(Asio_VERSION "${Asio_VERSION_MAJOR}.${Asio_VERSION_MINOR}.${Asio_VERSION_PATCH}")
+            set(tmp_asio_version ${CMAKE_MATCH_1})
+            math(EXPR Asio_VERSION_MAJOR "${tmp_asio_version} / 100000")
+            math(EXPR Asio_VERSION_MINOR "${tmp_asio_version} / 100 % 1000")
+            math(EXPR Asio_VERSION_PATCH "${tmp_asio_version} % 100")
+            set(Asio_VERSION "${Asio_VERSION_MAJOR}.${Asio_VERSION_MINOR}.${Asio_VERSION_PATCH}")
 
-			unset(tmp_version)
-			unset(tmp_asio_version)
+            unset(tmp_version)
+            unset(tmp_asio_version)
 
-			if (${Asio_VERSION} VERSION_LESS 1.28)
-				unset(Asio_INCLUDE_DIR)
-				unset(Asio_VERSION)
-				unset(Asio_VERSION_MAJOR)
-				unset(Asio_VERSION_MINOR)
-				unset(Asio_VERSION_PATCH)
-			else()
-				set(Asio_FOUND ON)
-				message(STATUS "Found Asio ${Asio_VERSION} at ${Asio_INCLUDE_DIR}")
-			endif()
-		endif()
+            if (${Asio_VERSION} VERSION_LESS 1.28)
+                unset(Asio_INCLUDE_DIR)
+                unset(Asio_VERSION)
+                unset(Asio_VERSION_MAJOR)
+                unset(Asio_VERSION_MINOR)
+                unset(Asio_VERSION_PATCH)
+            else()
+                set(Asio_FOUND ON)
+                message(STATUS "Found Asio ${Asio_VERSION} at ${Asio_INCLUDE_DIR}")
+            endif()
+        endif()
 
-		if (NOT Asio_FOUND AND GRPCXX_HERMETIC_BUILD)
-			FetchContent_Declare(asio
-				URL      https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-29-0.tar.gz
-				URL_HASH SHA256=44305859b4e6664dbbf853c1ef8ca0259d694f033753ae309fcb2534ca20f721
-			)
-			FetchContent_MakeAvailable(asio)
+        if (NOT Asio_FOUND AND GRPCXX_HERMETIC_BUILD)
+            FetchContent_Declare(asio
+                URL      https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-29-0.tar.gz
+                URL_HASH SHA256=44305859b4e6664dbbf853c1ef8ca0259d694f033753ae309fcb2534ca20f721
+            )
+            FetchContent_MakeAvailable(asio)
 
-			set(Asio_INCLUDE_DIR "$<BUILD_INTERFACE:${asio_SOURCE_DIR}/asio/include>")
-		endif()
+            set(Asio_INCLUDE_DIR "$<BUILD_INTERFACE:${asio_SOURCE_DIR}/asio/include>")
+        endif()
 
-		target_include_directories(asio INTERFACE ${Asio_INCLUDE_DIR})
-		target_compile_definitions(asio
-			INTERFACE
-				ASIO_NS=::asio
-				ASIO_STANDALONE
-				ASIO_NO_DEPRECATED
-		)
-	endif()
+        target_include_directories(asio INTERFACE ${Asio_INCLUDE_DIR})
+        target_compile_definitions(asio
+            INTERFACE
+                ASIO_NS=::asio
+                ASIO_STANDALONE
+                ASIO_NO_DEPRECATED
+        )
+    endif()
 endif()
 
 # nghttp2
 if(NOT GRPCXX_HERMETIC_BUILD)
-	find_package(PkgConfig REQUIRED)
-	pkg_check_modules(nghttp2 REQUIRED IMPORTED_TARGET "libnghttp2>=${NGHTTP2_MINVERSION}")
-	add_library(libnghttp2::nghttp2 ALIAS PkgConfig::nghttp2)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(nghttp2 REQUIRED IMPORTED_TARGET "libnghttp2>=${NGHTTP2_MINVERSION}")
+    add_library(libnghttp2::nghttp2 ALIAS PkgConfig::nghttp2)
 else()
-	FetchContent_Declare(nghttp2
-		URL      https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2_MINVERSION}/nghttp2-${NGHTTP2_MINVERSION}.tar.xz
-		URL_HASH SHA256=19490b7c8c2ded1cf7c3e3a54ef4304e3a7876ae2d950d60a81d0dc6053be419
-	)
+    FetchContent_Declare(nghttp2
+        URL      https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2_MINVERSION}/nghttp2-${NGHTTP2_MINVERSION}.tar.xz
+        URL_HASH SHA256=19490b7c8c2ded1cf7c3e3a54ef4304e3a7876ae2d950d60a81d0dc6053be419
+    )
 
-	set(ENABLE_LIB_ONLY   ON  CACHE BOOL "Build libnghttp2 only")
-	set(ENABLE_STATIC_LIB ON  CACHE BOOL "Build libnghttp2 in static mode")
-	set(ENABLE_SHARED_LIB OFF CACHE BOOL "Build libnghttp2 as a shared library")
-	set(ENABLE_DOC        OFF CACHE BOOL "Build libnghttp2 documentation")
+    set(ENABLE_LIB_ONLY   ON  CACHE BOOL "Build libnghttp2 only")
+    set(ENABLE_STATIC_LIB ON  CACHE BOOL "Build libnghttp2 in static mode")
+    set(ENABLE_SHARED_LIB OFF CACHE BOOL "Build libnghttp2 as a shared library")
+    set(ENABLE_DOC        OFF CACHE BOOL "Build libnghttp2 documentation")
+    FetchContent_MakeAvailable(nghttp2)
+    
+    target_include_directories(nghttp2_static
+        PUBLIC
+            $<BUILD_INTERFACE:${nghttp2_SOURCE_DIR}/lib/includes>
+    )
 
-	FetchContent_MakeAvailable(nghttp2)
-	target_include_directories(nghttp2_static
-		PUBLIC
-			$<BUILD_INTERFACE:${nghttp2_SOURCE_DIR}/lib/includes>
-	)
-
-	install(TARGETS nghttp2_static EXPORT grpcxx COMPONENT Development)
-	add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)
+    install(TARGETS nghttp2_static EXPORT grpcxx COMPONENT Development)
+    add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)
 endif()
 
 # protobuf
 find_package(Protobuf ${PROTOBUF_MINVERSION} REQUIRED)
 
 if(NOT GRPCXX_HERMETIC_BUILD)
-	find_package(fmt ${FMT_MINVERSION} REQUIRED)
+    find_package(fmt ${FMT_MINVERSION} REQUIRED)
 else()
-	# fmt
-	FetchContent_Declare(fmt
-		URL      https://github.com/fmtlib/fmt/archive/refs/tags/${FMT_MINVERSION}.tar.gz
-		URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
-	)
-	FetchContent_MakeAvailable(fmt)
+    # fmt
+    FetchContent_Declare(fmt
+        URL      https://github.com/fmtlib/fmt/archive/refs/tags/${FMT_MINVERSION}.tar.gz
+        URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
+    )
+    FetchContent_MakeAvailable(fmt)
+endif()
+
+if(BUILD_TESTING)
+    if(NOT GRPCXX_HERMETIC_BUILD)
+        find_package(GTest REQUIRED)
+    else()
+        # Google Test
+        # 
+        # We follow https://github.com/google/googletest?tab=readme-ov-file#live-at-head
+        # as per upstream recommendations and pick up the main branch without hash.
+        #
+        FetchContent_Declare(googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_SHALLOW TRUE
+            GIT_TAG main
+            FIND_PACKAGE_ARGS NAMES GTest
+        )
+        FetchContent_MakeAvailable(googletest)
+    endif()
 endif()

--- a/docs/api.md
+++ b/docs/api.md
@@ -186,33 +186,6 @@ Listen and serve incoming gRPC requests.
 > [!IMPORTANT]
 > If used with Asio, this will create and run an `io_context` executor on the main thread.
 
-#### prepare (`libuv`, protected)
-
-|||
----------------------------------------------- | ---
-`void prepare(std::string_view ip, int port);` | (1) (`libuv`)
-`void prepare(int fd);`                        | (2) (`libuv`)
-
-This is a low-level API to be used in conjunction with (`process_pending()`[#process_pending]). It allows to prepare execution of the loop separately from running one iteration of the loop, which is desirable when integrating a `server` with an external event loop, such as another one provided by `libuv`, or similar (e.g. `libevent`).
-
-The method is marked as `protected` as this is not the normal use case; please subclass `server` to get access to it.
-
-#### process_pending (`libuv`, protected)
-
-|||
-------------------------- | ---
-`bool process_pending();` | (1) (`libuv`)
-
-This is a low-level API to be used in conjunction with (`prepare()`[#prepare]). It allows to execute a single non-blocking iteration of the internal `libuv` loop, which is desirable when integrating a `server` with an external event loop, such as another one provided by `libuv`, or similar (e.g. `libevent`).
-
-It will return `true` if there are still active operations that might become ready in the future, `false` otherwise.
-
-Differing from [run()](#run), no stop token can be passed, as only pending events are processed, without waiting.
-
-The method is marked as `protected` as this is not the normal use case; please subclass `server` to get access to it.
-
-Please note that it is the programmer's responsibility to ensure a call to `prepare()` precedes a call to `process_pending()`.
-
 ### Example (`asio`)
 
 ```cpp

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,8 @@
     - [add](#add)
     - [listen (`asio`)](#listen-asio)
     - [run](#run)
+    - [prepare (`libuv`, protected)](#prepare)
+    - [process_pending (`libuv`, protected)](#process-pending)
   - [Example (`asio`)](#example-asio)
   - [Example (`libuv`)](#example-uv)
 - [`grpcxx::context`](#grpcxxcontext)
@@ -175,8 +177,11 @@ _awaitable_ must be passed on to an `io_context` executor to serve requests.
 Listen and serve incoming gRPC requests.
 
 1. Start listening on `ip` and `port` for incoming gRPC connections and serve requests.
-2. Same as (1), but accepting an optional stop token to asynchronously signal the server to exit
-3. Start listening on the provided file descriptor `fd`, which needs to be already bound to a network address. This is useful when the socket needs to have some additional properties set (such as keep-alive) and/or reused from the outside run context (such as is the case of the [systemd socket activation protocol](https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html#)).
+2. Same as (1), but accepting an optional stop token to asynchronously signal the server to exit.
+3. Start listening on the provided file descriptor `fd`, which needs to be already bound to a network 
+   address. This is useful when the socket needs to have some additional properties set (such as 
+   keep-alive) and/or reused from the outside run context (such as is the case of the 
+   [systemd socket activation protocol](https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html#)).
 
 > [!IMPORTANT]
 > If used with Asio, this will create and run an `io_context` executor on the main thread.
@@ -188,7 +193,7 @@ Listen and serve incoming gRPC requests.
 `void prepare(std::string_view ip, int port);` | (1) (`libuv`)
 `void prepare(int fd);`                        | (2) (`libuv`)
 
-This is a lower-level API to be used in conjunction with (`process_pending()`[#process_pending]). It allows to prepare execution of the loop separately from running one iteration of the loop, which is desirable when integrating a `server` with an external event loop, such as another one provided by `libuv`, or similar (e.g. `libevent`).
+This is a low-level API to be used in conjunction with (`process_pending()`[#process_pending]). It allows to prepare execution of the loop separately from running one iteration of the loop, which is desirable when integrating a `server` with an external event loop, such as another one provided by `libuv`, or similar (e.g. `libevent`).
 
 The method is marked as `protected` as this is not the normal use case; please subclass `server` to get access to it.
 
@@ -196,9 +201,11 @@ The method is marked as `protected` as this is not the normal use case; please s
 
 |||
 ------------------------- | ---
-`void process_pending();` | (1) (`libuv`)
+`bool process_pending();` | (1) (`libuv`)
 
-This is a lower-level API to be used in conjunction with (`prepare()`[#prepare]). It allows to execute a single non-blocking iteration of the internal `libuv` loop, which is desirable when integrating a `server` with an external event loop, such as another one provided by `libuv`, or similar (e.g. `libevent`).
+This is a low-level API to be used in conjunction with (`prepare()`[#prepare]). It allows to execute a single non-blocking iteration of the internal `libuv` loop, which is desirable when integrating a `server` with an external event loop, such as another one provided by `libuv`, or similar (e.g. `libevent`).
+
+It will return `true` if there are still active operations that might become ready in the future, `false` otherwise.
 
 Differing from [run()](#run), no stop token can be passed, as only pending events are processed, without waiting.
 

--- a/lib/grpcxx/CMakeLists.txt
+++ b/lib/grpcxx/CMakeLists.txt
@@ -92,7 +92,16 @@ if (NOT GRPCXX_USE_ASIO)
 		PUBLIC
 			libuv::uv
 	)
-else()
+
+    # On Mac OS X, when libc++ is used with CLang,
+    # stop_token for some reason is still not stabilized.
+    # Therefore we enable experimental features.
+	target_compile_options(grpcxx
+        PUBLIC 
+            $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-fexperimental-library>
+	)
+
+else() # ASIO version
 	target_link_libraries(grpcxx
 		PUBLIC
 			asio

--- a/lib/grpcxx/service.h
+++ b/lib/grpcxx/service.h
@@ -46,7 +46,7 @@ public:
 	using handler_t  = std::function<response_t(context &, std::string_view)>;
 	using handlers_t = std::unordered_map<std::string_view, handler_t>;
 
-	template <typename I> constexpr service(I &impl) {
+	template <typename I> constexpr explicit service(I &impl) {
 		std::apply(
 			[&](auto &&...args) {
 				auto helper = [&](const auto &rpc) {

--- a/lib/grpcxx/uv/server.cpp
+++ b/lib/grpcxx/uv/server.cpp
@@ -4,6 +4,7 @@
 #include "coroutine.h"
 #include "uv.h"
 
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 #include <stdexcept>
@@ -14,6 +15,13 @@ namespace grpcxx {
 namespace uv {
 server::server(std::size_t n) noexcept : _scheduler(_loop, n) {
 	uv_tcp_init(_loop, &_handle);
+	_handle.data = this;
+}
+
+server::~server() noexcept {
+	if (uv_loop_alive(_loop)) {
+		uv_stop(_loop);
+	}
 }
 
 detail::coroutine server::conn(uv_stream_t *stream) {
@@ -45,39 +53,61 @@ void server::conn_cb(uv_stream_t *stream, int status) {
 	s->conn(stream);
 }
 
-void server::run(std::string_view ip, int port, std::stop_token stop_token) {
-	struct sockaddr_in addr;
-	uv_ip4_addr(ip.data(), port, &addr);
+void server::prepare(std::string_view ip, int port) {
+	sockaddr_storage addr;
+	if (uv_ip4_addr(ip.data(), port, reinterpret_cast<sockaddr_in *>(&addr)) != 0 &&
+		uv_ip6_addr(ip.data(), port, reinterpret_cast<sockaddr_in6 *>(&addr)) != 0) {
+		throw std::runtime_error(std::string(ip) + " is not a valid IPv4 or IPv6 address");
+	}
 
 	if (auto r = uv_tcp_bind(&_handle, reinterpret_cast<const sockaddr *>(&addr), 0); r != 0) {
 		throw std::runtime_error(std::string("Failed to bind to tcp address: ") + uv_strerror(r));
 	}
 
-	run(_handle, std::move(stop_token));
+	start_listening();
 }
 
-void server::run(int fd, std::stop_token stop_token) {
-	if (auto r = uv_tcp_open(&_handle, fd); r != 0) {
+void server::prepare(int fd) {
+	struct sockaddr_in addr;
+	socklen_t          addr_len = sizeof(addr);
+	if (auto r = uv_tcp_open(&_handle, fd);
+		r != 0 || getsockname(fd, (struct sockaddr *)&addr, &addr_len) != 0) {
+
 		throw std::runtime_error(
 			std::string("Provided fd ") + std::to_string(fd) +
 			" is not a bound network socket: " + uv_strerror(r));
 	}
 
-	run(_handle, std::move(stop_token));
+	start_listening();
 }
 
-void server::run(uv_tcp_t &handle, std::stop_token stop_token) {
-	if (auto r = uv_listen(reinterpret_cast<uv_stream_t *>(&handle), TCP_LISTEN_BACKLOG, conn_cb);
+void server::start_listening() {
+	if (auto r = uv_listen(reinterpret_cast<uv_stream_t *>(&_handle), TCP_LISTEN_BACKLOG, conn_cb);
 		r != 0) {
 		throw std::runtime_error(
 			std::string("Failed to listen for connections: ") + uv_strerror(r));
 	}
+}
 
+void server::run(std::string_view ip, int port, std::stop_token stop_token) {
+	prepare(std::move(ip), port);
+	setup_stop_timer(std::move(stop_token));
+	uv_run(_loop, UV_RUN_DEFAULT);
+}
+
+void server::run(int fd, std::stop_token stop_token) {
+	prepare(fd);
+	setup_stop_timer(std::move(stop_token));
+	uv_run(_loop, UV_RUN_DEFAULT);
+}
+
+void server::setup_stop_timer(std::stop_token stop_token) noexcept {
 	// See https://docs.libuv.org/en/v1.x/guide/eventloops.html#stopping-an-event-loop
 	// for a rationale around the shutdown timer.
 
+	_stop_token = std::move(stop_token);
 	uv_timer_init(_loop, &_check_stop_timer);
-	_check_stop_timer.data = &stop_token;
+	_check_stop_timer.data = &_stop_token;
 	uv_timer_start(
 		&_check_stop_timer,
 		[](uv_timer_t *handle) {
@@ -89,9 +119,10 @@ void server::run(uv_tcp_t &handle, std::stop_token stop_token) {
 		},
 		SHUTDOWN_CHECK_INTERVAL_MS,
 		SHUTDOWN_CHECK_INTERVAL_MS);
+}
 
-	handle.data = this;
-	uv_run(_loop, UV_RUN_DEFAULT);
+bool server::process_pending() {
+	return static_cast<bool>(uv_run(_loop, UV_RUN_NOWAIT));
 }
 
 server::loop_t::loop_t() {

--- a/lib/grpcxx/uv/server.cpp
+++ b/lib/grpcxx/uv/server.cpp
@@ -4,7 +4,10 @@
 #include "coroutine.h"
 #include "uv.h"
 
+#include <sys/socket.h>
+
 #include <stdexcept>
+#include <stop_token>
 #include <string>
 
 namespace grpcxx {
@@ -42,7 +45,7 @@ void server::conn_cb(uv_stream_t *stream, int status) {
 	s->conn(stream);
 }
 
-void server::run(std::string_view ip, int port) {
+void server::run(std::string_view ip, int port, std::stop_token stop_token) {
 	struct sockaddr_in addr;
 	uv_ip4_addr(ip.data(), port, &addr);
 
@@ -50,19 +53,66 @@ void server::run(std::string_view ip, int port) {
 		throw std::runtime_error(std::string("Failed to bind to tcp address: ") + uv_strerror(r));
 	}
 
-	run(std::move(_handle));
+	run(_handle, std::move(stop_token));
 }
 
-void server::run(uv_tcp_t &&handle) {
-	_handle      = std::move(handle);
-	_handle.data = this;
+void server::run(int fd, std::stop_token stop_token) {
+	if (auto r = uv_tcp_open(&_handle, fd); r != 0) {
+		throw std::runtime_error(
+			std::string("Provided fd ") + std::to_string(fd) +
+			" is not a bound network socket: " + uv_strerror(r));
+	}
 
-	if (auto r = uv_listen(reinterpret_cast<uv_stream_t *>(&_handle), 128, conn_cb); r != 0) {
+	run(_handle, std::move(stop_token));
+}
+
+void server::run(uv_tcp_t &handle, std::stop_token stop_token) {
+	if (auto r = uv_listen(reinterpret_cast<uv_stream_t *>(&handle), TCP_LISTEN_BACKLOG, conn_cb);
+		r != 0) {
 		throw std::runtime_error(
 			std::string("Failed to listen for connections: ") + uv_strerror(r));
 	}
 
+	// See https://docs.libuv.org/en/v1.x/guide/eventloops.html#stopping-an-event-loop
+	// for a rationale around the shutdown timer.
+
+	uv_timer_init(_loop, &_check_stop_timer);
+	_check_stop_timer.data = &stop_token;
+	uv_timer_start(
+		&_check_stop_timer,
+		[](uv_timer_t *handle) {
+			const auto stop_token = static_cast<const std::stop_token *>(handle->data);
+			if (stop_token->stop_requested()) {
+				uv_timer_stop(handle);
+				uv_stop(handle->loop);
+			}
+		},
+		SHUTDOWN_CHECK_INTERVAL_MS,
+		SHUTDOWN_CHECK_INTERVAL_MS);
+
+	handle.data = this;
 	uv_run(_loop, UV_RUN_DEFAULT);
+}
+
+server::loop_t::loop_t() {
+	uv_loop_init(&_loop);
+}
+
+server::loop_t::~loop_t() noexcept {
+	// Ensures all remaining handles are cleaned up (but without any
+	// special close callback)
+	uv_walk(
+		&_loop,
+		[](uv_handle_t *handle, void *) {
+			if (!uv_is_closing(handle)) {
+				uv_close(handle, nullptr);
+			}
+		},
+		nullptr);
+
+	while (uv_loop_close(&_loop) == UV_EBUSY) {
+		uv_run(&_loop, UV_RUN_ONCE);
+	}
 }
 
 } // namespace uv

--- a/lib/grpcxx/uv/server.h
+++ b/lib/grpcxx/uv/server.h
@@ -21,6 +21,7 @@ public:
 	server(const server &) = delete;
 	server(std::size_t n = std::thread::hardware_concurrency()) noexcept;
 
+	void run(uv_tcp_t &&handle);
 	void run(std::string_view ip, int port);
 
 private:

--- a/lib/grpcxx/uv/server.h
+++ b/lib/grpcxx/uv/server.h
@@ -18,8 +18,11 @@ struct coroutine;
 
 class server : public ::grpcxx::server_base {
 public:
-	server(const server &) = delete;
 	server(std::size_t n = std::thread::hardware_concurrency()) noexcept;
+
+	server(const server &) = delete;
+
+	virtual ~server() noexcept;
 
 	/// Allow running against an existing uv_tcp_t handle
 	///
@@ -36,6 +39,43 @@ public:
 
 	void run(std::string_view ip, int port, std::stop_token stop_token = {});
 
+protected:
+	/// Lower-level API for integration in other event loops
+	///
+	/// This API prepares the server for listening to connections,
+	/// but does not run the internal loop, which is deferred to
+	/// calling run_once().
+	///
+	/// This is useful for integration in other event loops
+	/// (or nesting `uv_loop_t`s).
+	///
+	void prepare(int fd);
+
+	/// Lower-level API for integration in other event loops
+	///
+	/// This API prepares the server for listening to connections
+	/// over a pre-built, bound socket, but does not run the internal
+	/// loop, which is deferred to calling run_once().
+	///
+	/// This is useful for integration in other event loops
+	/// (or nesting `uv_loop_t`s).
+	///
+	void prepare(std::string_view ip, int port);
+
+	/// Dispatch current events and return
+	///
+	/// This mode of operation is useful to run only a single iteration
+	/// of the UV loop, for instance for integration in other event-based
+	/// frameworks such as libevent or nesting loops in libuv.
+	///
+	/// It will return `true` if there are still active operations that
+	/// might become ready in the future, `false` otherwise.
+	///
+	/// Please note that you are responsible to ensure a call to prepare()
+	/// before calling process_pending().
+	///
+	bool process_pending();
+
 private:
 	static constexpr int      TCP_LISTEN_BACKLOG         = 128;
 	static constexpr uint64_t SHUTDOWN_CHECK_INTERVAL_MS = 100;
@@ -51,13 +91,17 @@ private:
 
 	static void conn_cb(uv_stream_t *stream, int status);
 
-	void run(uv_tcp_t &handle, std::stop_token stop_token = {});
+	void start_listening();
+
+	void setup_stop_timer(std::stop_token stop_token) noexcept;
 
 	detail::coroutine conn(uv_stream_t *stream);
 
-	uv_tcp_t   _handle;
-	loop_t     _loop;
-	uv_timer_t _check_stop_timer;
+	uv_run_mode     _run_mode;
+	uv_tcp_t        _handle;
+	loop_t          _loop;
+	uv_timer_t      _check_stop_timer;
+	std::stop_token _stop_token;
 
 	detail::scheduler _scheduler;
 };

--- a/lib/grpcxx/uv/server.h
+++ b/lib/grpcxx/uv/server.h
@@ -6,8 +6,8 @@
 
 #include <uv.h>
 
+#include <stop_token>
 #include <string_view>
-#include <thread>
 
 namespace grpcxx {
 namespace uv {
@@ -21,12 +21,28 @@ public:
 	server(const server &) = delete;
 	server(std::size_t n = std::thread::hardware_concurrency()) noexcept;
 
-	void run(uv_tcp_t &&handle);
-	void run(std::string_view ip, int port);
+	/// Allow running against an existing uv_tcp_t handle
+	///
+	/// This is especially useful when using socket-activation
+	/// (when the socket already exists at the application start,
+	/// e.g. when using the systemd socket activation protocol),
+	/// or when it is necessary to do additional setup on the socket,
+	/// such as setting keep-alive options.
+	///
+	/// Please note that this will take ownership of the file
+	/// descriptor, and close it as necessary.
+	///
+	void run(int fd, std::stop_token stop_token = {});
+
+	void run(std::string_view ip, int port, std::stop_token stop_token = {});
 
 private:
+	static constexpr int      TCP_LISTEN_BACKLOG         = 128;
+	static constexpr uint64_t SHUTDOWN_CHECK_INTERVAL_MS = 100;
+
 	struct loop_t {
-		loop_t() { uv_loop_init(&_loop); }
+		loop_t();
+		~loop_t() noexcept;
 
 		operator uv_loop_t *() noexcept { return &_loop; }
 
@@ -35,10 +51,13 @@ private:
 
 	static void conn_cb(uv_stream_t *stream, int status);
 
+	void run(uv_tcp_t &handle, std::stop_token stop_token = {});
+
 	detail::coroutine conn(uv_stream_t *stream);
 
-	uv_tcp_t _handle;
-	loop_t   _loop;
+	uv_tcp_t   _handle;
+	loop_t     _loop;
+	uv_timer_t _check_stop_timer;
 
 	detail::scheduler _scheduler;
 };

--- a/src/protoc-gen-grpcxx/grpcxx.cpp
+++ b/src/protoc-gen-grpcxx/grpcxx.cpp
@@ -48,7 +48,10 @@ bool Grpcxx::Generate(
 		output       += fmt::format("namespace {} {{\n", service->name());
 
 		std::string tmp = fmt::format(
-			"using Service = grpcxx::service<\"{}.{}\"", file->package(), service->name());
+			"using Service = grpcxx::service<\"{}{}{}\"",
+			file->package(),
+			file->package().empty() ? "" : ".",
+			service->name());
 
 		for (int j = 0; j < service->method_count(); j++) {
 			auto method = service->method(j);
@@ -57,7 +60,7 @@ bool Grpcxx::Generate(
 			// e.g. `google.protobuf.Empty` -> `google::protobuf::Empty`
 			auto mapper = [&file](const google::protobuf::Descriptor *t) -> std::string {
 				auto name = t->full_name();
-				if (name.starts_with(file->package())) {
+				if (!file->package().empty() && name.starts_with(file->package())) {
 					name = name.substr(file->package().size() + 1);
 				}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(GoogleTest)
+
+add_executable(grpcxx-unit-tests)
+target_sources(grpcxx-unit-tests
+    PRIVATE
+        sanity_check.cpp)
+target_link_libraries(grpcxx-unit-tests
+    PRIVATE GTest::gtest_main)
+
+gtest_discover_tests(grpcxx-unit-tests
+    XML_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,42 @@ target_sources(grpcxx-unit-tests
         sanity_check.cpp
 )
 
+set(proto_files
+    proto/ping_pong.proto)
+
+foreach(proto IN LISTS proto_files)
+    cmake_path(REMOVE_EXTENSION proto 
+        LAST_ONLY
+        OUTPUT_VARIABLE stem)
+    set(stem ${CMAKE_CURRENT_BINARY_DIR}/${stem})
+
+    cmake_path(REMOVE_FILENAME proto 
+        OUTPUT_VARIABLE dir)
+    set(destdir "${CMAKE_CURRENT_BINARY_DIR}/${dir}")
+    
+    file(MAKE_DIRECTORY ${destdir})
+
+    add_custom_command(
+        OUTPUT ${stem}.grpcxx.pb.h
+               ${stem}.pb.h
+               ${stem}.pb.cc
+        COMMAND protobuf::protoc
+                    "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}/proto"
+                    "--cpp_out=${destdir}"
+                    "--grpcxx_out=${destdir}"
+                    "--plugin=$<TARGET_FILE:protoc-gen-grpcxx>"
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${proto}
+        COMMENT "Generating sources from ${proto}"
+        VERBATIM
+    )
+
+    target_sources(grpcxx-unit-tests
+        PRIVATE ${stem}.pb.cc)
+endforeach()
+
+target_include_directories(grpcxx-unit-tests
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/proto)
+
 if(NOT GRPCXX_USE_ASIO)
     # libuv-related test sources
     target_sources(grpcxx-unit-tests
@@ -16,6 +52,7 @@ endif()
 
 target_link_libraries(grpcxx-unit-tests
     PRIVATE GTest::gtest_main
+            protobuf::libprotobuf
             grpcxx
             fmt::fmt)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,9 +3,21 @@ include(GoogleTest)
 add_executable(grpcxx-unit-tests)
 target_sources(grpcxx-unit-tests
     PRIVATE
-        sanity_check.cpp)
+        sanity_check.cpp
+)
+
+if(NOT GRPCXX_USE_ASIO)
+    # libuv-related test sources
+    target_sources(grpcxx-unit-tests
+        PRIVATE
+            uv/server.cpp
+    )
+endif()
+
 target_link_libraries(grpcxx-unit-tests
-    PRIVATE GTest::gtest_main)
+    PRIVATE GTest::gtest_main
+            grpcxx
+            fmt::fmt)
 
 gtest_discover_tests(grpcxx-unit-tests
     XML_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/proto/ping_pong.proto
+++ b/test/proto/ping_pong.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message Ping {}
+message Pong {}
+
+service PingPong {
+	rpc hello(Ping) returns (Pong);
+}

--- a/test/sanity_check.cpp
+++ b/test/sanity_check.cpp
@@ -2,7 +2,7 @@
 
 namespace /* anonymous */ {
 
-TEST(SanityCheck, ItWorks) {
+TEST(SanityCheck, GTestWorks) {
 	// Trivial assertion to verify the
 	// test harness works.
 	ASSERT_TRUE(true);

--- a/test/sanity_check.cpp
+++ b/test/sanity_check.cpp
@@ -1,0 +1,11 @@
+#include "gtest/gtest.h"
+
+namespace /* anonymous */ {
+
+TEST(SanityCheck, ItWorks) {
+	// Trivial assertion to verify the
+	// test harness works.
+	ASSERT_TRUE(true);
+}
+
+} // namespace

--- a/test/sanity_check.cpp
+++ b/test/sanity_check.cpp
@@ -2,7 +2,7 @@
 
 namespace /* anonymous */ {
 
-TEST(SanityCheck, GTestWorks) {
+TEST(SanityCheck, googletest_works) {
 	// Trivial assertion to verify the
 	// test harness works.
 	ASSERT_TRUE(true);

--- a/test/uv/server.cpp
+++ b/test/uv/server.cpp
@@ -2,12 +2,22 @@
 
 #include "gtest/gtest.h"
 
+#include "ping_pong.grpcxx.pb.h"
+#include "uv.h"
+
 #include <fmt/core.h>
 #include <sys/socket.h>
 
 #include <cstring>
 #include <stop_token>
 #include <thread>
+
+template <>
+auto PingPong::ServiceImpl::call<PingPong::rpchello>(grpcxx::context &, const Ping &req)
+	-> rpchello::result_type {
+	Pong res;
+	return {grpcxx::status::code_t::ok, res};
+}
 
 namespace /* anonymous */ {
 
@@ -28,14 +38,20 @@ struct fd_t {
 	int _fd;
 };
 
-TEST(UvServer, RunWithAddressAndStop) {
-	grpcxx::uv::server server{1};
-	auto               thr = std::jthread{[&server](std::stop_token stop_token) {
-        server.run("127.0.0.1", 0, std::move(stop_token));
-    }};
+TEST(UvServer, run_with_address_and_stop) {
+	grpcxx::uv::server    server{1};
+	PingPong::ServiceImpl ping_pong;
+	PingPong::Service     service{ping_pong};
+	server.add(service);
+
+	auto thr = std::jthread{
+		[&server](std::stop_token stop_token) { server.run("::1", 0, std::move(stop_token)); }};
+
+	// TODO: we should do an exchange here, as soon as grpcxx also provides
+	// a client. So far this was tested manually via Postman.
 }
 
-TEST(UvServer, RunWithExistingFdAndStop) {
+TEST(UvServer, run_with_existing_fd_and_stop) {
 	sockaddr_in addr;
 	socklen_t   addr_len{sizeof(addr)};
 
@@ -48,11 +64,62 @@ TEST(UvServer, RunWithExistingFdAndStop) {
 	addr.sin_port        = htons(0); // 0 means any available port
 
 	ASSERT_GE(0, bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)));
+	auto port = ntohs(addr.sin_port);
 
-	grpcxx::uv::server server{1};
+	grpcxx::uv::server    server{1};
+	PingPong::ServiceImpl ping_pong;
+	PingPong::Service     service{ping_pong};
+	server.add(service);
+
 	auto fd  = sockfd.release(); // the server will take ownership, and it will close it.
 	auto thr = std::jthread{
 		[&server, fd](std::stop_token stop_token) { server.run(fd, std::move(stop_token)); }};
+
+	// TODO: we should do an exchange here, as soon as grpcxx also provides
+	// a client. So far this was tested manually via Postman.
+}
+
+TEST(UvServer, run_in_nested_loop) {
+	class server : public ::grpcxx::uv::server {
+	public:
+		server() : ::grpcxx::uv::server{1} { prepare("127.0.0.1", 0); }
+
+		void process_pending() { ::grpcxx::uv::server::process_pending(); }
+	};
+
+	server                server;
+	PingPong::ServiceImpl ping_pong;
+	PingPong::Service     service{ping_pong};
+	server.add(service);
+
+	// Integration with other event loops, such as the one of libevent,
+	// is possible. Here we just nest uv loops to avoid introducing
+	// additional dependencies and show how this can be achieved without
+	// the need of moving the server to additional threads.
+	uv_loop_t outer_loop;
+	uv_loop_init(&outer_loop);
+
+	uv_timer_t inner_loop_timer;
+	uv_timer_init(&outer_loop, &inner_loop_timer);
+	inner_loop_timer.data = &server;
+	uv_timer_start(
+		&inner_loop_timer,
+		[](uv_timer_t *handle) {
+			auto server = static_cast<class server *>(handle->data);
+			server->process_pending();
+		},
+		0,
+		0);
+	uv_run(&outer_loop, UV_RUN_DEFAULT);
+
+	// TODO: we should do an exchange here, as soon as grpcxx also provides
+	// a client. So far this was tested manually via Postman (with a non-zero
+	// repeat value for the timer).
+
+	// Cleanup
+	uv_close(reinterpret_cast<uv_handle_t *>(&inner_loop_timer), nullptr);
+	uv_run(&outer_loop, UV_RUN_DEFAULT);
+	uv_loop_close(&outer_loop);
 }
 
 } // namespace

--- a/test/uv/server.cpp
+++ b/test/uv/server.cpp
@@ -1,0 +1,58 @@
+#include "grpcxx/uv/server.h"
+
+#include "gtest/gtest.h"
+
+#include <fmt/core.h>
+#include <sys/socket.h>
+
+#include <cstring>
+#include <stop_token>
+#include <thread>
+
+namespace /* anonymous */ {
+
+struct fd_t {
+	fd_t(int fd) : _fd(fd) {}
+	fd_t(const fd_t &) = delete;
+	fd_t(fd_t &&that) : _fd(that.release()) {}
+	~fd_t() { close(_fd); }
+
+	int release() {
+		using std::swap;
+		int ret = -1;
+		swap(ret, _fd);
+		return ret;
+	}
+	operator int() const { return _fd; }
+
+	int _fd;
+};
+
+TEST(UvServer, RunWithAddressAndStop) {
+	grpcxx::uv::server server{1};
+	auto               thr = std::jthread{[&server](std::stop_token stop_token) {
+        server.run("127.0.0.1", 0, std::move(stop_token));
+    }};
+}
+
+TEST(UvServer, RunWithExistingFdAndStop) {
+	sockaddr_in addr;
+	socklen_t   addr_len{sizeof(addr)};
+
+	auto sockfd = fd_t{socket(AF_INET, SOCK_STREAM, 0)};
+	ASSERT_GE(sockfd, 0);
+
+	std::memset(&addr, 0, sizeof(addr));
+	addr.sin_family      = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	addr.sin_port        = htons(0); // 0 means any available port
+
+	ASSERT_GE(0, bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)));
+
+	grpcxx::uv::server server{1};
+	auto fd  = sockfd.release(); // the server will take ownership, and it will close it.
+	auto thr = std::jthread{
+		[&server, fd](std::stop_token stop_token) { server.run(fd, std::move(stop_token)); }};
+}
+
+} // namespace


### PR DESCRIPTION
This change adds:
 
  - socket activation support, to allow the caller to pass a
    pre-existing bound tcp socket to server::run(). This
    is important in contexts where it is necessary to set
    some particular flags on the socket (such as keepalive),
    or if the socket is already created at program start
    (as is the case with the systemd socket activation protocol).
  - server shutdown support, to allow signaling the server
    via a `std::stop_token` that it should clean up and cleanly exit.
  - integration to other event loops, by subclassing `uv::server`
    and allowing iterating through the loop just once.
    
Three unit tests were added. Running valgrind on the resulting
binary also revealed a leak due to failure to cleanup a
the `uv_handle_t` with the connection, this is now taken care of
in the destructor of `grpcxx::uv::server::loop_t`. Valgrind
does not report any more leaks during test execution.

Additionally, a bug in the generation of sources from proto
files when no package name is present was fixed.
