### PR TITLE
Windows builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,6 +112,7 @@ jobs:
           - cl
         variant:
           # [Nov. 2024] msvc throws C2894 errors when using libuv, need to investigate why
+          # Ref: https://github.com/uatuko/grpcxx/pull/46
           # - libuv
           - asio
         include:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,37 +104,56 @@ jobs:
           cmake --build .build --config Release
 
   windows:
-    # Windows builds are broken at the moment, disable until they are fixed
-    if: false
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
+        compiler:
+          - cl
         variant:
-          - libuv
+          # [Nov. 2024] msvc throws C2894 errors when using libuv, need to investigate why
+          # - libuv
           - asio
         include:
           - variant: asio
             cmake_args: -DGRPCXX_USE_ASIO=ON
 
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
+        id: cache-restore-vcpkg
         with:
           path: C:\vcpkg\packages
           key: ${{ runner.arch }}_${{ runner.os }}-vcpkg-20241101
-      - name: Install dependencies
-        run: |
-          choco install ninja
-          vcpkg install protobuf
+
+      - name: Install dependencies (choco)
+        run: choco install ninja
+      - name: Install dependencies (vcpkg)
+        if: steps.cache-restore-vcpkg.outputs.cache-hit != 'true'
+        run: vcpkg install protobuf
+
+      # Always save vcpkg cache if vcpkg install is successful
+      - uses: actions/cache/save@v4
+        if: always() && steps.cache-restore-vcpkg.outputs.cache-hit != 'true'
+        id: cache-save-vcpkg
+        with:
+          path: C:\vcpkg\packages
+          key: ${{ steps.cache-restore-vcpkg.outputs.cache-primary-key }}
+
+      # It's not straight forward to setup dev commant prompt to use across steps. Have to find the location and execute
+      # `vcvarsall.bat ${{ runner.arch }}` and "export" env vars set by vcvarsall.bat.
+      - uses: ilammy/msvc-dev-cmd@v1
+
       - uses: actions/checkout@v4
       - name: Configure CMake
         run: |
           cmake -B .build -G Ninja `
+            -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} `
             -DCMAKE_BUILD_TYPE=Release `
             -DGRPCXX_BUILD_EXAMPLES=OFF `
             -DGRPCXX_BUILD_EXPERIMENTS=OFF `
             -DGRPCXX_BUILD_TESTING=OFF `
             -DProtobuf_ROOT=C:\vcpkg\packages\protobuf_x64-windows `
+            -DCMAKE_CXX_FLAGS="-DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include" `
             ${{ matrix.cmake_args }}
       - name: Build
         run: cmake --build .build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
+option(BUILD_SHARED_LIBS "Build grpcxx as a shared library" ON)
 option(GRPCXX_HERMETIC_BUILD "Fetch and build all dependencies instead of relying on system libraries" ON)
 option(GRPCXX_USE_ASIO "Use asio instead of libuv for I/O and event loop" OFF)
 
@@ -19,13 +20,13 @@ cmake_dependent_option(GRPCXX_BUILD_EXAMPLES
 )
 
 cmake_dependent_option(GRPCXX_BUILD_EXPERIMENTS
-	"Build experiments when this is the root project" ON
+	"Build experiments when this is the root project and not using asio" ON
 	"NOT GRPCXX_USE_ASIO; CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF
 )
 
 cmake_dependent_option(GRPCXX_BUILD_TESTING
-	"Build tests when BUILD_TESTING flag is set and this is the root project" ON
-	"BUILD_TESTING; CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF
+	"Build tests when BUILD_TESTING flag is set or this is the root project" ON
+	"BUILD_TESTING OR CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF
 )
 
 include(cmake/dependencies.cmake)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 set(LIBUV_MINVERSION 1.46.0)
 set(BOOST_MINVERSION 1.81)
-set(NGHTTP2_MINVERSION 1.55.1)
+set(NGHTTP2_MINVERSION 1.64.0)
 set(PROTOBUF_MINVERSION 3.15.0)
 set(FMT_MINVERSION 10.1.1)
 set(GTEST_MINVERSION 1.15.2)
@@ -100,19 +100,14 @@ if(NOT GRPCXX_HERMETIC_BUILD)
 else()
     FetchContent_Declare(nghttp2
         URL      https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2_MINVERSION}/nghttp2-${NGHTTP2_MINVERSION}.tar.xz
-        URL_HASH SHA256=19490b7c8c2ded1cf7c3e3a54ef4304e3a7876ae2d950d60a81d0dc6053be419
+        URL_HASH SHA256=88bb94c9e4fd1c499967f83dece36a78122af7d5fb40da2019c56b9ccc6eb9dd
     )
 
     set(ENABLE_LIB_ONLY   ON  CACHE BOOL "Build libnghttp2 only")
-    set(ENABLE_STATIC_LIB ON  CACHE BOOL "Build libnghttp2 in static mode")
-    set(ENABLE_SHARED_LIB OFF CACHE BOOL "Build libnghttp2 as a shared library")
+    set(BUILD_STATIC_LIBS ON  CACHE BOOL "Build libnghttp2 in static mode")
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libnghttp2 as a shared library")
     set(ENABLE_DOC        OFF CACHE BOOL "Build libnghttp2 documentation")
     FetchContent_MakeAvailable(nghttp2)
-
-    target_include_directories(nghttp2_static
-        PUBLIC
-            $<BUILD_INTERFACE:${nghttp2_SOURCE_DIR}/lib/includes>
-    )
 
     install(TARGETS nghttp2_static EXPORT grpcxx COMPONENT Development)
     add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -15,10 +15,16 @@ if(NOT GRPCXX_USE_ASIO)
             URL_HASH SHA256=7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
         )
 
-        set(LIBUV_BUILD_SHARED OFF CACHE BOOL "Build libuv shared lib")
+        set(LIBUV_BUILD_SHARED ${BUILD_SHARED_LIBS} CACHE BOOL "Build libuv shared lib")
         FetchContent_MakeAvailable(libuv)
-        install(TARGETS uv_a EXPORT grpcxx COMPONENT Development)
-        add_library(libuv::uv ALIAS uv_a)
+
+        if (BUILD_SHARED_LIBS)
+            install(TARGETS uv EXPORT grpcxx COMPONENT Development)
+            add_library(libuv::uv ALIAS uv)
+        else()
+            install(TARGETS uv_a EXPORT grpcxx COMPONENT Development)
+            add_library(libuv::uv ALIAS uv_a)
+        endif()
     else()
         # Unfortunately the libuv CMakeLists.txt does not export
         # a version file. This is a bug in libuv.
@@ -103,14 +109,20 @@ else()
         URL_HASH SHA256=88bb94c9e4fd1c499967f83dece36a78122af7d5fb40da2019c56b9ccc6eb9dd
     )
 
+    if (NOT BUILD_SHARED_LIBS)
+        set(BUILD_STATIC_LIBS ON CACHE BOOL "Build libnghttp2 in static mode")
+    endif()
     set(ENABLE_LIB_ONLY   ON  CACHE BOOL "Build libnghttp2 only")
-    set(BUILD_STATIC_LIBS ON  CACHE BOOL "Build libnghttp2 in static mode")
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libnghttp2 as a shared library")
     set(ENABLE_DOC        OFF CACHE BOOL "Build libnghttp2 documentation")
     FetchContent_MakeAvailable(nghttp2)
 
-    install(TARGETS nghttp2_static EXPORT grpcxx COMPONENT Development)
-    add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)
+    if (BUILD_SHARED_LIBS)
+        install(TARGETS nghttp2 EXPORT grpcxx COMPONENT Development)
+        add_library(libnghttp2::nghttp2 ALIAS nghttp2)
+    else()
+        install(TARGETS nghttp2_static EXPORT grpcxx COMPONENT Development)
+        add_library(libnghttp2::nghttp2 ALIAS nghttp2_static)
+    endif()
 endif()
 
 # protobuf

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 # API Documentation
 
 > [!WARNING]
-> `grpcxx::detail` namespace is considered internal and may change without any warning.
+> `*::detail` namespaces are considered internal and may change without any warning.
 
 > [!IMPORTANT]
 > (`asio`) indicates it's only available when using Asio (i.e. compiled with `GRPCXX_USE_ASIO`).
@@ -170,16 +170,16 @@ _awaitable_ must be passed on to an `io_context` executor to serve requests.
 ------------------------------------------------- | ---
 `void run(const std::string_view &ip, int port);`                           | (1) (`asio`)
 `void run(std::string_view ip, int port, std::stop_token stop_token = {});` | (2) (`libuv`)
-`void run(int fd, std::stop_token stop_token = {});`                        | (3) (`libuv`)
+`void run(uv_os_sock_t sock, std::stop_token stop_token = {});`             | (3) (`libuv`)
 
 Listen and serve incoming gRPC requests.
 
 1. Start listening on `ip` and `port` for incoming gRPC connections and serve requests.
 2. Same as (1), but accepting an optional stop token to asynchronously signal the server to exit.
-3. Start listening on the provided file descriptor `fd`, which needs to be already bound to a network 
-   address. This is useful when the socket needs to have some additional properties set (such as 
-   keep-alive) and/or reused from the outside run context (such as is the case of the 
-   [systemd socket activation protocol](https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html#)).
+3. Start listening on the provided tcp socket `sock`, which needs to be already bound to a network
+   address. This is useful when the socket needs to have some additional properties set (such as
+   keep-alive) and/or reused from the outside run context (such as is the case of the
+   [systemd socket activation protocol](https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html)).
 
 > [!IMPORTANT]
 > If used with Asio, this will create and run an `io_context` executor on the main thread.

--- a/lib/grpcxx/h2/session.h
+++ b/lib/grpcxx/h2/session.h
@@ -38,7 +38,7 @@ private:
 		nghttp2_session *session, const nghttp2_frame *frame, const uint8_t *name, size_t namelen,
 		const uint8_t *value, size_t valuelen, uint8_t flags, void *vsess);
 
-	static ssize_t read_cb(
+	static nghttp2_ssize read_cb(
 		nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t length,
 		uint32_t *data_flags, nghttp2_data_source *source, void *);
 

--- a/lib/grpcxx/uv/server.h
+++ b/lib/grpcxx/uv/server.h
@@ -36,7 +36,7 @@ public:
 	/// Please note that this will take ownership of the file
 	/// descriptor, and close it as necessary.
 	///
-	void run(int fd, std::stop_token stop_token = {});
+	void run(uv_os_sock_t sock, std::stop_token stop_token = {});
 
 	void run(std::string_view ip, int port, std::stop_token stop_token = {});
 
@@ -56,7 +56,7 @@ protected:
 	/// This is useful for integration in other event loops
 	/// (or nesting `uv_loop_t`s).
 	///
-	void prepare(int fd);
+	void prepare(uv_os_sock_t sock);
 
 	/// Lower-level API for integration in other event loops
 	///


### PR DESCRIPTION
- [x] Avoid using `ssize_t` (a28b43920e7a224a0239edb2f116323da14b6a58)
- [x] Avoid using *nix only headers when using libuv (a469f4d14ecbad379327ed03008c2b67db63d7b4)

## Unresolved issues

### 1. Examples can't be built

Looks like there's an issue with protobuf (or cmake configs) where it's failing to find `protoc`?

```
ninja: error: 'examples/errors/proto/protobuf::protoc', needed by 'examples/errors/proto/examples/v1/errors.grpcxx.pb.h', missing and no known rule to make it
```

### 2. Error C2894 when building with libuv

```
71/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\uv\loop.cpp.obj
FAILED: lib/grpcxx/CMakeFiles/grpcxx.dir/uv/loop.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DNGHTTP2_STATICLIB -ID:\a\grpcxx\grpcxx\lib\grpcxx\.. -ID:\a\grpcxx\grpcxx\lib\grpcxx -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-src\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-build\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\libuv-src\include -DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /Folib\grpcxx\CMakeFiles\grpcxx.dir\uv\loop.cpp.obj /Fdlib\grpcxx\CMakeFiles\grpcxx.dir\grpcxx.pdb /FS -c D:\a\grpcxx\grpcxx\lib\grpcxx\uv\loop.cpp
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(8): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(34): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(39): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\rpc.h(12): error C2894: templates cannot be declared to have 'C' linkage
```
<details>
<summary>Build logs</summary>

Ref: https://github.com/uatuko/grpcxx/actions/runs/11645652496/job/32428922875

```
[1/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\strtok.c.obj
[2/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\thread-common.c.obj
[3/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\strscpy.c.obj
[4/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\idna.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(35): warning C4245: 'return': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(69): warning C4245: 'return': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(73): warning C4245: 'return': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(81): warning C4245: 'return': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(84): warning C4245: 'return': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(87): warning C4245: 'return': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(161): warning C4244: '=': conversion from 'unsigned int' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(181): warning C4245: '=': conversion from 'int' to 'unsigned int', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\idna.c(314): warning C4244: 'return': conversion from '__int64' to 'long', possible loss of data
[5/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\fs-poll.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\fs-poll.c(200): warning C4244: 'function': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\fs-poll.c(203): warning C4244: '=': conversion from 'ssize_t' to 'int', possible loss of data
[6/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\random.c.obj
[7/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\inet.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\inet.c(160): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\inet.c(193): warning C4244: '=': conversion from 'unsigned int' to 'unsigned char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\inet.c(187): warning C4244: 'initializing': conversion from '__int64' to 'unsigned int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\inet.c(283): warning C4244: 'initializing': conversion from '__int64' to 'const int', possible loss of data
[8/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\threadpool.c.obj
[9/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\version.c.obj
[10/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\timer.c.obj
[11/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\uv-data-getter-setters.c.obj
[12/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\uv-common.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\uv-common.c(170): warning C4245: 'return': conversion from 'int' to 'size_t', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\uv-common.c(178): warning C4245: 'return': conversion from 'int' to 'size_t', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\uv-common.c(257): warning C4244: 'function': conversion from 'int' to 'u_short', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\uv-common.c(272): warning C4244: 'function': conversion from 'int' to 'u_short', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\uv-common.c(715): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
[13/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\error.c.obj
[14/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\async.c.obj
[15/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\core.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\core.c(470): warning C4244: '=': conversion from 'uint64_t' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\core.c(564): warning C4244: '=': conversion from 'uint64_t' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\core.c(470) : warning C4701: potentially uninitialized local variable 'user_timeout' used
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\core.c(564) : warning C4701: potentially uninitialized local variable 'user_timeout' used
[16/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\detect-wakeup.c.obj
[17/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\dl.c.obj
[18/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\getnameinfo.c.obj
[19/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\handle.c.obj
[20/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\fs-event.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs-event.c(483): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
[21/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\loop-watcher.c.obj
[22/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\fs.c.obj
C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um\winioctl.h(264): warning C4005: 'CTL_CODE': macro redefinition
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\winapi.h(4496): note: see previous definition of 'CTL_CODE'
C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um\winioctl.h(313): warning C4005: 'FILE_READ_ACCESS': macro redefinition
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\winapi.h(4488): note: see previous definition of 'FILE_READ_ACCESS'
C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um\winioctl.h(314): warning C4005: 'FILE_WRITE_ACCESS': macro redefinition
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\winapi.h(4492): note: see previous definition of 'FILE_WRITE_ACCESS'
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(106): warning C4244: '+=': conversion from 'double' to 'long', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(213): warning C4244: '=': conversion from 'int' to 'WCHAR', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(216): warning C4244: '=': conversion from 'int32_t' to 'WCHAR', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(395): warning C4244: '=': conversion from 'int32_t' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(397): warning C4244: '=': conversion from 'int32_t' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(400): warning C4244: '=': conversion from 'int32_t' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(404): warning C4244: '=': conversion from 'int32_t' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(531): warning C4267: '=': conversion from 'size_t' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(1460): warning C4245: '=': conversion from 'int' to 'DWORD', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2282): warning C4267: 'function': conversion from 'size_t' to 'unsigned int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2328): warning C4245: '=': conversion from 'int' to 'DWORD', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2432): warning C4244: 'initializing': conversion from 'double' to 'int64_t', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2433): warning C4244: 'initializing': conversion from 'double' to 'int64_t', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2552): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2609): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2610): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2638): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2639): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2652): warning C4244: '=': conversion from 'int' to 'USHORT', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(2914): warning C4267: 'function': conversion from 'size_t' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3063): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3068): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3075): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3108): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3141): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3153): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3156): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3168): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3172): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3186): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3189): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3203): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3206): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3217): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3220): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3232): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3236): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3249): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3251): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3268): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3281): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3292): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3295): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3307): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3311): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3323): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3326): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3344): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3347): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3359): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3362): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3369): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3381): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3384): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3395): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3398): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3409): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3412): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3419): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3431): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3434): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3441): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3448): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3457): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3481): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3485): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3495): warning C4267: '=': conversion from 'size_t' to 'ULONG', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3496): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3511): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3515): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3527): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3531): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3540): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3552): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3557): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3567): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3578): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3583): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3597): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(3600): warning C4244: 'return': conversion from 'ssize_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(1022) : warning C4701: potentially uninitialized local variable 'original_position' used
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\fs.c(1227) : warning C4701: potentially uninitialized local variable 'original_position' used
[23/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\poll.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\poll.c(495): warning C4244: '=': conversion from 'int' to 'unsigned char', possible loss of data
[24/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\thread.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\thread.c(207): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\thread.c(208): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\thread.c(421) : warning C4702: unreachable code
[25/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\snprintf.c.obj
[26/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\pipe.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\pipe.c(1332): warning C4244: 'function': conversion from 'ULONG_PTR' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\pipe.c(1351): warning C4244: 'function': conversion from 'ULONG_PTR' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\pipe.c(2454): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\pipe.c(2580): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\pipe.c(837) : warning C4701: potentially uninitialized local variable 'duplex_flags' used
[27/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\signal.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\signal.c(212): warning C4189: 'r': local variable is initialized but not referenced
[28/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\process-stdio.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\process-stdio.c(260) : warning C4701: potentially uninitialized local variable 'fdopt' used
[29/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\stream.c.obj
[30/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\tcp.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tcp.c(354): warning C4244: 'function': conversion from 'ULONG_PTR' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tcp.c(373): warning C4244: 'function': conversion from 'ULONG_PTR' to 'DWORD', possible loss of data
[31/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\udp.c.obj
[32/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\getaddrinfo.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\getaddrinfo.c(131): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\getaddrinfo.c(434): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
[33/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_pq.c.obj
[34/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\winapi.c.obj
[35/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\tty.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(981): warning C4244: 'initializing': conversion from 'ULONG_PTR' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1122): warning C4244: '=': conversion from 'UINT' to 'WORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1362): warning C4244: 'function': conversion from 'int' to 'unsigned char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1362): warning C4244: 'function': conversion from 'int' to 'unsigned char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1363): warning C4244: 'function': conversion from 'int' to 'unsigned char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1363): warning C4244: 'function': conversion from 'int' to 'unsigned char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1459): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1468): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1478): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1483): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1570): warning C4244: '=': conversion from 'int' to 'SHORT', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(1892): warning C4244: '=': conversion from 'unsigned int' to 'unsigned short', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(2219): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\tty.c(2392) : warning C4702: unreachable code
[36/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_map.c.obj
[37/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_queue.c.obj
[38/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\winsock.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\winsock.c(518) : warning C4701: potentially uninitialized local variable 'iosb' used
[39/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_buf.c.obj
[40/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_frame.c.obj
[41/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_stream.c.obj
[42/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_outbound_item.c.obj
[43/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_submit.c.obj
[44/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_helper.c.obj
[45/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_alpn.c.obj
[46/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\util.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1081): warning C4267: 'function': conversion from 'size_t' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1114): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1289): warning C4245: '=': conversion from 'int' to 'unsigned long', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1290): warning C4245: '=': conversion from 'int' to 'unsigned long', signed/unsigned mismatch
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1415): warning C4267: '=': conversion from 'size_t' to 'DWORD', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1453): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1800): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\util.c(1859): warning C4267: 'function': conversion from 'size_t' to 'ULONG', possible loss of data
[47/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_hd_huffman_data.c.obj
[48/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_version.c.obj
[49/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_hd_huffman.c.obj
[50/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_priority_spec.c.obj
[51/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_hd.c.obj
[52/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_callbacks.c.obj
[53/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_option.c.obj
[54/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_mem.c.obj
[55/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_rcbuf.c.obj
[56/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_extpri.c.obj
[57/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_ratelim.c.obj
[58/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_http.c.obj
[59/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_debug.c.obj
[60/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_session.c.obj
[61/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\sfparse.c.obj
[62/83] Building C object _deps\nghttp2-build\lib\CMakeFiles\nghttp2_static.dir\nghttp2_time.c.obj
[63/83] Linking C static library _deps\nghttp2-build\lib\nghttp2.lib
[64/83] Building C object _deps\libuv-build\CMakeFiles\uv_a.dir\src\win\process.c.obj
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\process.c(637): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\process.c(757): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\process.c(793): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\grpcxx\grpcxx\.build\_deps\libuv-src\src\win\process.c(812): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
[65/83] Linking C static library _deps\libuv-build\libuv.lib
[66/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\message.cpp.obj
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\optional(82): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\optional(82): note: the template instantiation context (the oldest one first) is
D:\a\grpcxx\grpcxx\lib\grpcxx\message.cpp(10): note: see reference to function template instantiation 'std::optional<uint32_t>::optional<unsigned __int64,0>(_Ty2 &&) noexcept' being compiled
        with
        [
            _Ty2=unsigned __int64
        ]
D:\a\grpcxx\grpcxx\lib\grpcxx\message.cpp(10): note: see the first reference to 'std::optional<uint32_t>::optional' in 'grpcxx::detail::message::message'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\optional(248): note: see reference to function template instantiation 'std::_Optional_construct_base<_Ty>::_Optional_construct_base<unsigned __int64>(std::in_place_t,unsigned __int64 &&)' being compiled
        with
        [
            _Ty=uint32_t
        ]
D:\a\grpcxx\grpcxx\lib\grpcxx\message.cpp(81): note: see reference to function template instantiation 'std::_Optional_destruct_base<_Ty,true>::_Optional_destruct_base<unsigned __int64>(std::in_place_t,unsigned __int64 &&) noexcept' being compiled
        with
        [
            _Ty=uint32_t
        ]
[67/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\context.cpp.obj
[68/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\request.cpp.obj
D:\a\grpcxx\grpcxx\lib\grpcxx\request.cpp(78): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
[69/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\server_base.cpp.obj
D:\a\grpcxx\grpcxx\lib\grpcxx\server_base.cpp(19): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
[70/83] Building CXX object _deps\fmt-build\CMakeFiles\fmt.dir\src\os.cc.obj
D:\a\grpcxx\grpcxx\.build\_deps\fmt-src\src\os.cc(143): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
[71/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\uv\loop.cpp.obj
FAILED: lib/grpcxx/CMakeFiles/grpcxx.dir/uv/loop.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DNGHTTP2_STATICLIB -ID:\a\grpcxx\grpcxx\lib\grpcxx\.. -ID:\a\grpcxx\grpcxx\lib\grpcxx -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-src\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-build\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\libuv-src\include -DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /Folib\grpcxx\CMakeFiles\grpcxx.dir\uv\loop.cpp.obj /Fdlib\grpcxx\CMakeFiles\grpcxx.dir\grpcxx.pdb /FS -c D:\a\grpcxx\grpcxx\lib\grpcxx\uv\loop.cpp
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(8): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(34): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(39): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\rpc.h(12): error C2894: templates cannot be declared to have 'C' linkage
[72/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\uv\reader.cpp.obj
FAILED: lib/grpcxx/CMakeFiles/grpcxx.dir/uv/reader.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DNGHTTP2_STATICLIB -ID:\a\grpcxx\grpcxx\lib\grpcxx\.. -ID:\a\grpcxx\grpcxx\lib\grpcxx -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-src\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-build\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\libuv-src\include -DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /Folib\grpcxx\CMakeFiles\grpcxx.dir\uv\reader.cpp.obj /Fdlib\grpcxx\CMakeFiles\grpcxx.dir\grpcxx.pdb /FS -c D:\a\grpcxx\grpcxx\lib\grpcxx\uv\reader.cpp
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(8): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(34): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(39): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\rpc.h(12): error C2894: templates cannot be declared to have 'C' linkage
[73/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\uv\conn.cpp.obj
FAILED: lib/grpcxx/CMakeFiles/grpcxx.dir/uv/conn.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DNGHTTP2_STATICLIB -ID:\a\grpcxx\grpcxx\lib\grpcxx\.. -ID:\a\grpcxx\grpcxx\lib\grpcxx -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-src\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-build\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\libuv-src\include -DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /Folib\grpcxx\CMakeFiles\grpcxx.dir\uv\conn.cpp.obj /Fdlib\grpcxx\CMakeFiles\grpcxx.dir\grpcxx.pdb /FS -c D:\a\grpcxx\grpcxx\lib\grpcxx\uv\conn.cpp
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(8): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(34): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(39): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\rpc.h(12): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\uv\task.h(50): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
[74/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\uv\scheduler.cpp.obj
FAILED: lib/grpcxx/CMakeFiles/grpcxx.dir/uv/scheduler.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DNGHTTP2_STATICLIB -ID:\a\grpcxx\grpcxx\lib\grpcxx\.. -ID:\a\grpcxx\grpcxx\lib\grpcxx -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-src\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-build\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\libuv-src\include -DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /Folib\grpcxx\CMakeFiles\grpcxx.dir\uv\scheduler.cpp.obj /Fdlib\grpcxx\CMakeFiles\grpcxx.dir\grpcxx.pdb /FS -c D:\a\grpcxx\grpcxx\lib\grpcxx\uv\scheduler.cpp
D:\a\grpcxx\grpcxx\lib\grpcxx\uv\task.h(50): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(8): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(34): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(39): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\rpc.h(12): error C2894: templates cannot be declared to have 'C' linkage
[75/83] Building CXX object lib\grpcxx\CMakeFiles\grpcxx.dir\uv\server.cpp.obj
FAILED: lib/grpcxx/CMakeFiles/grpcxx.dir/uv/server.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DNGHTTP2_STATICLIB -ID:\a\grpcxx\grpcxx\lib\grpcxx\.. -ID:\a\grpcxx\grpcxx\lib\grpcxx -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-src\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\nghttp2-build\lib\includes -ID:\a\grpcxx\grpcxx\.build\_deps\libuv-src\include -DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /Folib\grpcxx\CMakeFiles\grpcxx.dir\uv\server.cpp.obj /Fdlib\grpcxx\CMakeFiles\grpcxx.dir\grpcxx.pdb /FS -c D:\a\grpcxx\grpcxx\lib\grpcxx\uv\server.cpp
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(8): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(34): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\fixed_string.h(39): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\rpc.h(12): error C2894: templates cannot be declared to have 'C' linkage
D:\a\grpcxx\grpcxx\lib\grpcxx\uv\task.h(50): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
[76/83] Building CXX object _deps\fmt-build\CMakeFiles\fmt.dir\src\format.cc.obj
D:\a\grpcxx\grpcxx\.build\_deps\fmt-src\include\fmt/format-inl.h(1406): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
ninja: build stopped: subcommand failed.
```
</details>