### PR TITLE
Avoid defining BUILD_SHARED_LIBS cmake variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - g++
           - clang++
+          - g++
         container:
           - ubuntu:24.04
         variant:
-          - libuv
           - asio
+          - libuv
         include:
           - compiler: g++
             dependencies: g++
@@ -53,6 +53,7 @@ jobs:
           cmake -B .build -G Ninja \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
             -DGRPCXX_BUILD_TESTING=OFF \
             ${{ matrix.cmake_args }}
       - name: Build
@@ -67,11 +68,11 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - g++
           - clang++
+          - g++
         variant:
-          - libuv
           - boost_asio
+          - libuv
         include:
           - variant: boost_asio
             cmake_args: -DGRPCXX_USE_ASIO=ON
@@ -96,6 +97,7 @@ jobs:
           cmake -B .build -G Ninja \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
             -DGRPCXX_BUILD_TESTING=OFF \
             ${{ matrix.cmake_args }}
       - name: Build
@@ -149,6 +151,7 @@ jobs:
           cmake -B .build -G Ninja `
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} `
             -DCMAKE_BUILD_TYPE=Release `
+            -DBUILD_SHARED_LIBS=ON `
             -DGRPCXX_BUILD_EXAMPLES=OFF `
             -DGRPCXX_BUILD_EXPERIMENTS=OFF `
             -DGRPCXX_BUILD_TESTING=OFF `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,7 @@ jobs:
           cmake -B .build -G Ninja \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
             -DGRPCXX_BUILD_EXAMPLES=OFF \
             -DGRPCXX_BUILD_EXPERIMENTS=OFF \
             ${{ matrix.cmake_args }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
-option(BUILD_SHARED_LIBS "Build grpcxx as a shared library" ON)
 option(GRPCXX_HERMETIC_BUILD "Fetch and build all dependencies instead of relying on system libraries" ON)
 option(GRPCXX_USE_ASIO "Use asio instead of libuv for I/O and event loop" OFF)
 


### PR DESCRIPTION
As a lib we shouldn't really be setting `BUILD_SHARED_LIBS` cmake variable, which can unintentionally cause projects importing grpcxx to build shared libs.