### PR TITLE
Fix string concatenation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,6 +78,8 @@ jobs:
           - variant: boost_asio
             cmake_args: -DGRPCXX_USE_ASIO=ON
             dependencies: boost
+          - variant: libuv
+            cmake_args: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     steps:
       - name: Install dependencies

--- a/src/protoc-gen-grpcxx/grpcxx.cpp
+++ b/src/protoc-gen-grpcxx/grpcxx.cpp
@@ -59,7 +59,7 @@ bool Grpcxx::Generate(
 			// Map proto types to c++ types
 			// e.g. `google.protobuf.Empty` -> `google::protobuf::Empty`
 			auto mapper = [&file](const google::protobuf::Descriptor *t) -> std::string {
-				auto name = t->full_name();
+				std::string_view name = t->full_name();
 				if (!file->package().empty() && name.starts_with(file->package())) {
 					name = name.substr(file->package().size() + 1);
 				}
@@ -68,7 +68,8 @@ bool Grpcxx::Generate(
 				std::size_t start = 0;
 				for (auto end = name.find('.'); end != std::string::npos;
 					 end      = name.find('.', start)) {
-					result += name.substr(start, end - start) + "::";
+					result += name.substr(start, end - start);
+					result += "::";
 					start   = end + 1;
 				}
 				result += name.substr(start);


### PR DESCRIPTION
It seems a newer release of protobuf has changed `(google::protobuf::Descriptor *)->full_name()` to return a `std::string_view` (instead of `std::string`), which breaks the `protoc-gen-grpcxx` build.

This changes fixes it, and also makes the change backwards compatible.

Fix #58.  