### PR TITLE
CMake >= 4.0 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,7 +159,7 @@ jobs:
             -DGRPCXX_BUILD_EXPERIMENTS=OFF `
             -DGRPCXX_BUILD_TESTING=OFF `
             -DProtobuf_ROOT=C:\vcpkg\packages\protobuf_x64-windows `
-            -DCMAKE_CXX_FLAGS="-DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include" `
+            -DCMAKE_CXX_FLAGS="-DNGHTTP2_NO_SSIZE_T -IC:\vcpkg\packages\abseil_x64-windows\include -IC:\vcpkg\packages\utf8-range_x64-windows\include" `
             ${{ matrix.cmake_args }}
       - name: Build
         run: cmake --build .build --config Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
           - clang++
           - g++
         container:
-          - ubuntu:24.04
+          - ubuntu:26.04
         variant:
           - asio
           - libuv
@@ -40,6 +40,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             ${{ matrix.dependencies }} \
+            ca-certificates \
             cmake ninja-build \
             libprotobuf-dev libprotoc-dev protobuf-compiler
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: ubuntu:24.04
+    container: ubuntu:26.04
 
     steps:
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         compiler:
           - g++
         container:
-          - ubuntu:24.04
+          - ubuntu:26.04
         variant:
           - libuv
           - asio
@@ -48,6 +48,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             ${{ matrix.dependencies }} \
+            ca-certificates \
             cmake ninja-build \
             libprotobuf-dev libprotoc-dev protobuf-compiler
       - uses: actions/checkout@v4

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -4,7 +4,7 @@ set(LIBUV_MINVERSION 1.51.0)
 set(BOOST_MINVERSION 1.81)
 set(NGHTTP2_MINVERSION 1.64.0)
 set(PROTOBUF_MINVERSION 3.15.0 CACHE STRING "Protobuf version")
-set(FMT_MINVERSION 10.1.1)
+set(FMT_MINVERSION 11.1.4)
 set(GTEST_MINVERSION 1.15.2)
 
 if(NOT GRPCXX_USE_ASIO)
@@ -134,7 +134,7 @@ else()
     # fmt
     FetchContent_Declare(fmt
         URL      https://github.com/fmtlib/fmt/archive/refs/tags/${FMT_MINVERSION}.tar.gz
-        URL_HASH SHA256=78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b
+        URL_HASH SHA256=ac366b7b4c2e9f0dde63a59b3feb5ee59b67974b14ee5dc9ea8ad78aa2c1ee1e
     )
     FetchContent_MakeAvailable(fmt)
 endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,6 +1,6 @@
 include(FetchContent)
 
-set(LIBUV_MINVERSION 1.46.0)
+set(LIBUV_MINVERSION 1.51.0)
 set(BOOST_MINVERSION 1.81)
 set(NGHTTP2_MINVERSION 1.64.0)
 set(PROTOBUF_MINVERSION 3.15.0 CACHE STRING "Protobuf version")
@@ -12,7 +12,7 @@ if(NOT GRPCXX_USE_ASIO)
         # libuv
         FetchContent_Declare(libuv
             URL      https://github.com/libuv/libuv/archive/refs/tags/v${LIBUV_MINVERSION}.tar.gz
-            URL_HASH SHA256=7aa66be3413ae10605e1f5c9ae934504ffe317ef68ea16fdaa83e23905c681bd
+            URL_HASH SHA256=27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
         )
 
         set(LIBUV_BUILD_SHARED ${BUILD_SHARED_LIBS} CACHE BOOL "Build libuv shared lib")


### PR DESCRIPTION
Close #60 

Use libuv >= 1.51.0 to avoid CMake compatibility errors. 

Also bump fmt to avoid compiler errors (ref: https://github.com/fmtlib/fmt/pull/4187). 